### PR TITLE
Everything up to sisyphus scripts start works

### DIFF
--- a/actions/create_sis_style_checksums.yaml
+++ b/actions/create_sis_style_checksums.yaml
@@ -1,7 +1,7 @@
 ---
-    name: 'rsync_file_list'
+    name: 'create_sis_style_checksums'
     runner_type: 'run-remote'
-    description: 'Create a list of files which will be rsynced based on the include file.'
+    description: 'Create a list of files and their md5sums based on a file list created by rsync, in the style that they have been created by Sisyphus.'
     enabled: true
     entry_point: ''
     parameters:
@@ -31,7 +31,7 @@
             position: 4
         cmd:
             immutable: true
-            default: 'export FOLDER={{ source }}; export FOLDER_NAME=$(basename $FOLDER); pushd $FOLDER/.. > /dev/null; rsync -vrktp --dry-run --chmod=Dg+sx,ug+w,o-rwx --prune-empty-dirs --include-from {{include_file}} ${FOLDER} /tmp | grep $FOLDER_NAME | grep -v "\/$" | xargs -0 -d"\n" md5sum > rsync.md5; popd > /dev/null'
+            default: 'export FOLDER={{ source }}; export FOLDER_NAME=$(basename $FOLDER); pushd $FOLDER/.. > /dev/null; if [ ! -e "$FOLDER/MD5" ]; then mkdir $FOLDER/MD5; fi; rsync -vrktp --dry-run --chmod=Dg+sx,ug+w,o-rwx --prune-empty-dirs --include-from {{include_file}} ${FOLDER} /tmp | grep $FOLDER_NAME | grep -v "\/$" | xargs -0 -d"\n" md5sum > $FOLDER/MD5/checksums.md5; popd > /dev/null'
             position: 0
         connect_timeout:
             type: 'integer'

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -35,6 +35,7 @@ workflows:
                     siswrap_service_port: <% $.get_config.result.siswrap_service_port %>
                     bcl2fastq_service_port: <% $.get_config.result.bcl2fastq_service_port %>
                     send_mail_to: <% $.get_config.result.send_mail_to %>
+                    remote_sisyphus_location: <% $.get_config.result.remote_sisyphus_location %>
                 on-success:
                     - get_runfolder_name
 
@@ -228,16 +229,34 @@ workflows:
                     cwd: <% $.remote_destination %>
                     cmd: md5sum -c <% $.remote_destination %>/<% $.runfolder_name %>/MD5/checksums.md5
                 on-success:
+                    - start_aeacus_stats
+
+            start_aeacus_stats:
+                action: core.remote
+                input:
+                    hosts: <% $.remote_host %>
+                    cwd: <% $.remote_destination %>/<% $.runfolder_name %>
+                    cmd: <% $.remote_sisyphus_location %>/aeacus-stats.pl -runfolder <% $.remote_destination %>/<% $.runfolder_name %>
+                on-success:
+                    - start_aeacus_report
+
+            start_aeacus_report:
+                action: core.remote
+                input:
+                    hosts: <% $.remote_host %>
+                    cwd: <% $.remote_destination %>/<% $.runfolder_name %>
+                    cmd: <% $.remote_sisyphus_location %>/aeacus-reports.pl -runfolder <% $.remote_destination %>/<% $.runfolder_name %>
+                on-success:
                     - notify_finished
 
-            rsync_to_summary_host:
-                action: arteria-packs.rsync
-                input:
-                    source: <% $.runfolder %>
-                    dest_server: <% $.summary_host %>
-                    destination: <% $.summary_destination %>
-                    include_file: /etc/arteria/misc/summary.rsync
-                    hosts: <% $.host %>
+#            rsync_to_summary_host:
+#                action: arteria-packs.rsync
+#                input:
+#                    source: <% $.runfolder %>
+#                    dest_server: <% $.summary_host %>
+#                    destination: <% $.summary_destination %>
+#                    include_file: /etc/arteria/misc/summary.rsync
+#                    hosts: <% $.host %>
             ### TRANSFER FILES TO UPPMAX END ###
 
             ### NOTIFIER START ###

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -189,15 +189,13 @@ workflows:
 
             ### TRANSFER FILES TO UPPMAX START ###
             create_md5sums_for_files_to_transfer:
-                action: arteria-packs.rsync_file_list
+                action: arteria-packs.create_sis_style_checksums
                 input:
                     source: <% $.runfolder %>
                     hosts: <% $.host %>
                     destination: /tmp/
                     dest_server: <% $.host %>
                     include_file: /etc/arteria/misc/hiseq.rsync
-                publish:
-                    md5_sums: <% $.create_md5sums_for_files_to_transfer.stdout %>
                 on-success:
                     - rsync_to_uppmax
                     - rsync_to_summary_host
@@ -210,6 +208,25 @@ workflows:
                     destination: <% $.remote_destination %>
                     include_file: /etc/arteria/misc/hiseq.rsync
                     hosts: <% $.host %>
+                on-success:
+                    - rsync_md5sums_to_uppmax
+
+            rsync_md5sums_to_uppmax:
+                action: linux.rsync
+                input:
+                    source: <% $.runfolder %>/MD5
+                    dest_server: <% $.remote_host %>
+                    destination: <% $.remote_destination %>/<% $.runfolder_name %>/
+                    hosts: <% $.host %>
+                on-success:
+                    - check_md5sums
+
+            check_md5sums:
+                action: core.remote
+                input:
+                    hosts: <% $.remote_host %>
+                    cwd: <% $.remote_destination %>
+                    cmd: md5sum -c <% $.remote_destination %>/<% $.runfolder_name %>/MD5/checksums.md5
                 on-success:
                     - notify_finished
 

--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,8 @@ summary_destination: /tmp/summaries/
 
 remote_host: testuppmax
 remote_destination: /tmp/runfolders/
+remote_sisyphus_location: /opt/arteria/arteria-siswrap-env/deps/sisyphus/sisyphus-latest
+
 
 send_mail_to: example.mail.address@send.errors.to
 


### PR DESCRIPTION
Now we create and check the MD5 checksums. It's written into the `<runfolder>/MD5/checksums.md5` directory, and the reason for that is that I believe that Sisyphus assumes that checksums are stored there.