### PR TITLE
Traciblity

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ Now you can search for the trace-tag using:
 
     st2 trace list --trace-tag 150605_M00485_0183_000000000-ABGT6_testbio14
     
-This will list all executions and triggers associated with the tag.
+To find more information about a particular trace, use:
+
+    st2 trace get <trace id>
     
-For automatic triggering the trace tagcan be injected via the sensor. For more info on traces, see: http://docs.stackstorm.com/traces.html
+From there you can go to getting more information on the executions using:
+
+    st2 execution get <execution id>
+       
+This will list all executions and triggers associated with the tag.
+
+All of this has been wrapped by `scripts/trace_runfolder.py`, which allows you to get all excutions of a workflow
+associated with a tag, e.g.:
+
+    python scripts/trace_runfolder.py --tag 150605_M00485_0183_000000000-ABGT6_testbio14 | xargs -n1 st2 execution get
+    
+For automatic triggering the trace tag can be injected via the sensor. For more info on traces, see: http://docs.stackstorm.com/traces.html

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -23,6 +23,14 @@ workflows:
 
         tasks:
             ### GENERAL TASKS START ###
+            note_workflow_hash:
+              action: core.local
+              input:
+                cmd: git rev-parse HEAD
+                cwd: /opt/stackstorm/packs/arteria-packs/
+              on-success:
+                 - get_config
+
             get_config:
               action: arteria-packs.get_pack_config
               publish:

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -23,7 +23,7 @@ workflows:
 
         tasks:
             ### GENERAL TASKS START ###
-            note_workflow_hash:
+            note_workflow_repo_version:
               action: core.local
               input:
                 cmd: git rev-parse HEAD

--- a/scripts/trace_runfolder.py
+++ b/scripts/trace_runfolder.py
@@ -2,12 +2,18 @@
 import os
 import requests
 import json
+import argparse
 
-# TODO Create commandline interface
+parser = argparse.ArgumentParser(description="Gets execution ids associated with a trace tag (e.g. a runfolder) and a "
+                                             "workflow. It can be used to track executions, e.g: "
+                                             "python scripts/trace_runfolder.py --tag 150605_M00485_0183_000000000-ABGT6_testbio14 | xargs -n1 st2 execution get")
+parser.add_argument('--tag', required=True)
+parser.add_argument('--api_base_url', default="http://localhost:9101/v1")
+parser.add_argument('--workflow', default="ngi_uu_workflow")
+args = parser.parse_args()
 
-api_base_url = "http://localhost:9101/v1"
-runfolder = "150605_M00485_0183_000000000-ABGT6_testbio14"
-workflow_name = "ngi_uu_workflow"
+api_base_url = args.api_base_url
+workflow_name = args.workflow
 
 # Try to load access token from environment - fall back if not available
 try:
@@ -15,13 +21,15 @@ try:
 except KeyError as e:
     print("Could not find ST2_AUTH_TOKEN in environment. Please set it to your st2 authentication token.")
 
-
 access_headers = {"X-Auth-Token": access_token}
 
 def get_traces_for_tag(tag, headers):
     traces_response = requests.get(
-        "{}/{}/?{}".format(api_base_url, "traces", "trace_tag=", tag),
+        "{}/{}/?{}={}".format(api_base_url, "traces", "trace_tag", tag),
         headers=headers)
+    if not traces_response.ok:
+        raise Exception("Response not OK, got: " + traces_response.text)
+
     return json.loads(traces_response.text)
 
 def get_executions_from_traces(traces, headers):
@@ -51,8 +59,10 @@ def get_actions_from_executions(executions, headers):
 def filter_actions_by_name(actions, name):
     return [action for action in actions if action["action"]["name"] == name]
 
-
-traces = get_traces_for_tag(runfolder, access_headers)
+# -----------
+# Main script
+# -----------
+traces = get_traces_for_tag(args.tag, access_headers)
 executions = get_executions_from_traces(traces, access_headers)
 actions = get_actions_from_executions(executions, access_headers)
 filtered_actions = filter_actions_by_name(actions, workflow_name)

--- a/scripts/trace_runfolder.py
+++ b/scripts/trace_runfolder.py
@@ -4,25 +4,6 @@ import requests
 import json
 import argparse
 
-parser = argparse.ArgumentParser(description="Gets execution ids associated with a trace tag (e.g. a runfolder) and a "
-                                             "workflow. It can be used to track executions, e.g: "
-                                             "python scripts/trace_runfolder.py --tag 150605_M00485_0183_000000000-ABGT6_testbio14 | xargs -n1 st2 execution get")
-parser.add_argument('--tag', required=True)
-parser.add_argument('--api_base_url', default="http://localhost:9101/v1")
-parser.add_argument('--workflow', default="ngi_uu_workflow")
-args = parser.parse_args()
-
-api_base_url = args.api_base_url
-workflow_name = args.workflow
-
-# Try to load access token from environment - fall back if not available
-try:
-    access_token = os.environ['ST2_AUTH_TOKEN']
-except KeyError as e:
-    print("Could not find ST2_AUTH_TOKEN in environment. Please set it to your st2 authentication token.")
-
-access_headers = {"X-Auth-Token": access_token}
-
 def get_traces_for_tag(tag, headers):
     traces_response = requests.get(
         "{}/{}/?{}={}".format(api_base_url, "traces", "trace_tag", tag),
@@ -33,7 +14,6 @@ def get_traces_for_tag(tag, headers):
     return json.loads(traces_response.text)
 
 def get_executions_from_traces(traces, headers):
-    executions = []
     for trace in traces:
         trace_id = trace["id"]
         trace_info_response = requests.get(
@@ -41,30 +21,46 @@ def get_executions_from_traces(traces, headers):
             headers=headers)
         trace_info = json.loads(trace_info_response.text)
         action_executions = map(lambda x: x["object_id"], trace_info["action_executions"])
-        executions += action_executions
-
-    return executions
+        for execution in action_executions:
+            yield execution
 
 def get_actions_from_executions(executions, headers):
-    actions = []
     for execution_id in executions:
         execution_info_response = requests.get(
             "{}/{}/{}".format(api_base_url, "executions", execution_id),
             headers=headers)
         execution_info = json.loads(execution_info_response.text)
-        actions.append(execution_info)
-
-    return actions
+        yield execution_info
 
 def filter_actions_by_name(actions, name):
-    return [action for action in actions if action["action"]["name"] == name]
+    return (action for action in actions if action["action"]["name"] == name)
 
-# -----------
-# Main script
-# -----------
-traces = get_traces_for_tag(args.tag, access_headers)
-executions = get_executions_from_traces(traces, access_headers)
-actions = get_actions_from_executions(executions, access_headers)
-filtered_actions = filter_actions_by_name(actions, workflow_name)
-for a in filtered_actions:
-    print a["id"]
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Gets execution ids associated with a trace tag (e.g. a runfolder) and a "
+                                             "workflow. It can be used to track executions, e.g: "
+                                             "python scripts/trace_runfolder.py --tag 150605_M00485_0183_000000000-ABGT6_testbio14 | xargs -n1 st2 execution get")
+    parser.add_argument('--tag', required=True)
+    parser.add_argument('--api_base_url', default="http://localhost:9101/v1")
+    parser.add_argument('--workflow', default="ngi_uu_workflow")
+    args = parser.parse_args()
+
+    api_base_url = args.api_base_url
+    workflow_name = args.workflow
+
+    # Try to load access token from environment - fall back if not available
+    try:
+        access_token = os.environ['ST2_AUTH_TOKEN']
+    except KeyError as e:
+        print("Could not find ST2_AUTH_TOKEN in environment. Please set it to your st2 authentication token.")
+
+    access_headers = {"X-Auth-Token": access_token}
+
+    traces = get_traces_for_tag(args.tag, access_headers)
+    executions = get_executions_from_traces(traces, access_headers)
+    #print list(executions)
+    actions = get_actions_from_executions(executions, access_headers)
+    filtered_actions = filter_actions_by_name(actions, workflow_name)
+    for a in filtered_actions:
+        print a["id"]

--- a/scripts/trace_runfolder.py
+++ b/scripts/trace_runfolder.py
@@ -1,0 +1,60 @@
+
+import os
+import requests
+import json
+
+# TODO Create commandline interface
+
+api_base_url = "http://localhost:9101/v1"
+runfolder = "150605_M00485_0183_000000000-ABGT6_testbio14"
+workflow_name = "ngi_uu_workflow"
+
+# Try to load access token from environment - fall back if not available
+try:
+    access_token = os.environ['ST2_AUTH_TOKEN']
+except KeyError as e:
+    print("Could not find ST2_AUTH_TOKEN in environment. Please set it to your st2 authentication token.")
+
+
+access_headers = {"X-Auth-Token": access_token}
+
+def get_traces_for_tag(tag, headers):
+    traces_response = requests.get(
+        "{}/{}/?{}".format(api_base_url, "traces", "trace_tag=", tag),
+        headers=headers)
+    return json.loads(traces_response.text)
+
+def get_executions_from_traces(traces, headers):
+    executions = []
+    for trace in traces:
+        trace_id = trace["id"]
+        trace_info_response = requests.get(
+            "{}/{}/{}".format(api_base_url, "traces", trace_id),
+            headers=headers)
+        trace_info = json.loads(trace_info_response.text)
+        action_executions = map(lambda x: x["object_id"], trace_info["action_executions"])
+        executions += action_executions
+
+    return executions
+
+def get_actions_from_executions(executions, headers):
+    actions = []
+    for execution_id in executions:
+        execution_info_response = requests.get(
+            "{}/{}/{}".format(api_base_url, "executions", execution_id),
+            headers=headers)
+        execution_info = json.loads(execution_info_response.text)
+        actions.append(execution_info)
+
+    return actions
+
+def filter_actions_by_name(actions, name):
+    return [action for action in actions if action["action"]["name"] == name]
+
+
+traces = get_traces_for_tag(runfolder, access_headers)
+executions = get_executions_from_traces(traces, access_headers)
+actions = get_actions_from_executions(executions, access_headers)
+filtered_actions = filter_actions_by_name(actions, workflow_name)
+for a in filtered_actions:
+    print a["id"]


### PR DESCRIPTION
Adding a `trace_runfolder.py` script, which can be used to trace all executions for a tag. Basically a utility wrapper for a few of the StackStorm API, but it should make things a lot smoother for the operator.