### PR TITLE
Initial template workflow for the Arteria template service

### DIFF
--- a/actions/template.yaml
+++ b/actions/template.yaml
@@ -1,0 +1,24 @@
+---
+name: template_workflow
+description: >
+  Run the Arteria template workflow. Provide a string to the web service, which
+  will ecoh it back to you.   
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/template.yaml
+pack: arteria-packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: arteria-packs.template_workflow
+    immutable: true
+    type: string
+  host:
+    default: "testarteria"
+    type: string
+  echostring:
+    required: false
+    type: string

--- a/actions/workflows/template.yaml
+++ b/actions/workflows/template.yaml
@@ -1,0 +1,33 @@
+version: "2.0" # mistral version
+name: arteria-packs.template_workflow
+description: The Arteria template workflow, echos a string
+
+workflows:
+    main:
+        type: direct
+        input:
+            - host
+            - echostring
+        output:
+            output_the_whole_workflow_context: <% $ %>
+
+        tasks:
+            call_echo_service:
+              action: core.http
+              input:               
+                url: http://<% $.host %>:2424/api/1.0/echo/<% $.echostring %>
+                method: "GET"
+              on-success:
+                - print_succes
+              on-error:
+                - print_failure
+
+            print_success:
+              action: core.local
+              input:
+                cmd: echo "Call returned <% $.call_echo_service.body.msg %>"
+
+            print_failure:
+              action: core.local
+              input:
+                cmd: echo "Something went wrong"


### PR DESCRIPTION
Can be used with e.g. https://github.com/johanherman/arteria-template

Moving service to arteria-project and provisioning it as well still TODO. 
