### PR TITLE
Set 24 h timeout on polling demux process

### DIFF
--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -123,6 +123,7 @@ workflows:
                 action: arteria-packs.poll_status
                 input:
                     url: <% $.bcl2fastq_status_url %>
+                    timeout: 86400 # Wait for 24 h before timing out.
                 on-success:
                     - download_sisyphus_config
             ## DEMULTIPLEX END ###


### PR DESCRIPTION
Since if we have many simultaneously running processes - we might need to wait for a long time to move beyond this step.