### PR TITLE
Change from 10 h to 24 h timeouts

### DIFF
--- a/actions/create_sis_style_checksums.yaml
+++ b/actions/create_sis_style_checksums.yaml
@@ -6,9 +6,9 @@
     entry_point: ''
     parameters:
         timeout:
-        # Use a default timeout of 10 hour. "No timout" is fixed in a new version
+        # Use a default timeout of 24 hour. "No timout" is fixed in a new version
         # https://github.com/StackStorm/st2/issues/1654
-            default: 36000
+            default: 86400
         source:
             type: 'string'
             description: 'List of files/directories to to be copied'

--- a/actions/poll_status.yaml
+++ b/actions/poll_status.yaml
@@ -6,9 +6,9 @@ enabled: true
 entry_point: lib/poll_status.py
 parameters:
     timeout:
-        # Use a default timeout of 10 hour. "No timout" is fixed in a new version
+        # Use a default timeout of 24 hour. "No timout" is fixed in a new version
         # https://github.com/StackStorm/st2/issues/1654
-        default: 36000
+        default: 86400
     url:
         type: string
         description: URL you want to poll for current status of long running process

--- a/actions/rsync.yaml
+++ b/actions/rsync.yaml
@@ -6,9 +6,9 @@
     entry_point: ''
     parameters:
         timeout:
-        # Use a default timeout of 10 hour. "No timout" is fixed in a new version
+        # Use a default timeout of 24 hour. "No timout" is fixed in a new version
         # https://github.com/StackStorm/st2/issues/1654
-            default: 36000
+            default: 86400
         source:
             type: 'string'
             description: 'List of files/directories to to be copied'

--- a/actions/workflows/sync_workflow.yaml
+++ b/actions/workflows/sync_workflow.yaml
@@ -74,6 +74,6 @@ workflows:
                     username: <% $.destination_user %>
                     cwd: <% $.destination_path %>
                     cmd: md5sum -c <% $.destination_path %>/<% $.runfolder_name %>/MD5/<% $.md5_output_file %>
-                    timeout: 36000 # 10 h timeout
+                    timeout: 86400 # 24 h timeout
 
             ### TRANSFER FILES END ###


### PR DESCRIPTION
Since quick-reports are not that quick, and resyncing TB is also slow business, we need longer timeouts.