### PR TITLE
Increase sensor poll time to 5 min

### DIFF
--- a/sensors/runfolder_sensor.yaml
+++ b/sensors/runfolder_sensor.yaml
@@ -2,7 +2,7 @@
   class_name: "RunfolderSensor"
   entry_point: "runfolder_sensor.py"
   description: "Sensor which monitors runfolders"
-  poll_interval: 30
+  poll_interval: 300 # Every 5 minutes
   trigger_types:
     -
       name: "runfolder_ready"


### PR DESCRIPTION
Right now we see problematic behaviour since the same runfolder gets
started multiple times when many things are running simultaneously.