### PR TITLE
Sync to irma and misc

### DIFF
--- a/actions/rsync.yaml
+++ b/actions/rsync.yaml
@@ -39,16 +39,11 @@
         connect_timeout:
             type: 'integer'
             description: 'SSH connect timeout in seconds'
-            default: 86400 # 24 h
-        dest_server_private_key:
-            type: 'string'
-            description: 'private key to dest server'
-            default: '/home/arteria/.ssh/biotank_key'
         args:
-            description: 'Command line arguments passed to rysnc'
-            default: '-vrktp --chmod=Dg+sx,ug+w,o-rwx --prune-empty-dirs -e \"ssh -o ConnectTimeout={{connect_timeout}} -i {{ dest_server_private_key }}\"'
+            description: 'Command line arguments passed to rsync'
+            default: '-vrktp --chmod=Dg+sx,ug+w,o-rwx --prune-empty-dirs -e \"ssh -o ConnectTimeout={{connect_timeout}} \"'
         cmd:
             immutable: true
-            default: 'ssh -v {{ source_host_user }}@{{ source_host }} rsync {{args}} {% if include_file %} --include-from {{ include_file }}  {% endif %}{{source}} {{dest_user}}@{{dest_server}}:{{destination}}/'
+            default: 'ssh -p -v {{ source_host_user }}@{{ source_host }} rsync {{args}} {% if include_file %} --include-from {{ include_file }}  {% endif %}{{source}} {{dest_user}}@{{dest_server}}:{{destination}}/'
             position: 0
 

--- a/actions/rsync.yaml
+++ b/actions/rsync.yaml
@@ -39,11 +39,12 @@
         connect_timeout:
             type: 'integer'
             description: 'SSH connect timeout in seconds'
+            default: 86400 # 24 h
         args:
             description: 'Command line arguments passed to rsync'
             default: '-vrktp --chmod=Dg+sx,ug+w,o-rwx --prune-empty-dirs -e \"ssh -o ConnectTimeout={{connect_timeout}} \"'
         cmd:
             immutable: true
-            default: 'ssh -p -v {{ source_host_user }}@{{ source_host }} rsync {{args}} {% if include_file %} --include-from {{ include_file }}  {% endif %}{{source}} {{dest_user}}@{{dest_server}}:{{destination}}/'
+            default: 'ssh -v {{ source_host_user }}@{{ source_host }} rsync {{args}} {% if include_file %} --include-from {{ include_file }}  {% endif %}{{source}} {{dest_user}}@{{dest_server}}:{{destination}}/'
             position: 0
 

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -28,8 +28,8 @@ workflows:
               input:
                 cmd: git rev-parse HEAD
                 cwd: /opt/stackstorm/packs/arteria-packs/
-            on-success:
-              - get_config
+              on-success:
+                - get_config
 
             get_config:
               action: arteria-packs.get_pack_config
@@ -208,7 +208,7 @@ workflows:
                 action: arteria-packs.poll_status
                 input:
                     url: <% $.qc_status_url %>
-               on-success:
+                on-success:
                     - rsync_to_summary_host
                 on-error:
                     # When we choose to ignore the sisphus qc rsults, just move on

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -28,8 +28,8 @@ workflows:
               input:
                 cmd: git rev-parse HEAD
                 cwd: /opt/stackstorm/packs/arteria-packs/
-              on-success:
-                 - get_config
+            on-success:
+              - get_config
 
             get_config:
               action: arteria-packs.get_pack_config

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -79,144 +79,144 @@ workflows:
                 publish:
                     flowcell_name: <% $.get_flowcell_name.result %>
                 on-success:
-                    #- download_samplesheet
-                    - rsync_to_summary_host
+                    - download_samplesheet
+
             ### GENERAL TASKS END ###
             ### DEMULTIPLEX START ###
-#            download_samplesheet:
-#                action: core.http
-#                input:
-#                    url: <% $.hermes_base_url %>/<% $.flowcell_name %>/samplesheetfile
-#                    headers: USER=<% $.hermes_user %>&X-XSRF-TOKEN=<% $.hermes_token %>
-#                publish:
-#                    samplesheet_string: <% $.download_samplesheet.body.samplesheet %>
-#                on-success:
-#                    - construct_bcl2fastq_body
-#
-#            # Since we don't want to pass empty values into
-#            # bcl2fastq-ws, we remove any empty keys from
-#            # this body.
-#            construct_bcl2fastq_body:
-#                action: arteria-packs.parse_bcl2fastq_args
-#                input:
-#                    samplesheet: "<% $.samplesheet_string %>"
-#                    bcl2fastq_version: "<% $.bcl2fastq_version %>"
-#                    barcode_mismatches: "<% $.barcode_mismatches %>"
-#                    tiles: "<% $.tiles %>"
-#                    use_base_mask: "<% $.use_base_mask %>"
-#                    additional_arguments: "<% $.bcl2fastq_additional_arguments %>"
-#                publish:
-#                    bcl2fastq_body: <% $.construct_bcl2fastq_body.stdout %>
-#                on-success:
-#                    - run_bcl2fastq
-#
-#            run_bcl2fastq:
-#                action: core.http
-#                input:
-#                    url: "http://<% $.host %>:<% $.bcl2fastq_service_port %>/api/1.0/start/<% $.runfolder_name %>"
-#                    method: "POST"
-#                    headers: "Content-Type=application/json"
-#                    body: <% $.bcl2fastq_body %>
-#                publish:
-#                    bcl2fastq_status_url: <% $.run_bcl2fastq.body.link %>
-#                on-success:
-#                    - poll_demultiplex_status
-#
-#            poll_demultiplex_status:
-#                action: arteria-packs.poll_status
-#                input:
-#                    url: <% $.bcl2fastq_status_url %>
-#                    timeout: 86400 # Wait for 24 h before timing out.
-#                on-success:
-#                    - download_sisyphus_config
-#            ## DEMULTIPLEX END ###
-#            ### QUICK REPORT START ###
-#            download_sisyphus_config:
-#                action: core.http
-#                input:
-#                    url: <% $.hermes_base_url %>/<% $.flowcell_name %>/configfile
-#                    headers: USER=<% $.hermes_user %>&X-XSRF-TOKEN=<% $.hermes_token %>
-#                publish:
-#                    sisyphus_conf_string: <% $.download_sisyphus_config.body.config %>
-#                on-success:
-#                    - construct_report_body
-#
-#            construct_report_body:
-#                action: arteria-packs.parse_siswrap_args
-#                input:
-#                    runfolder: "<% $.runfolder_name %>"
-#                    sisyphus_config: "<% $.sisyphus_conf_string %>"
-#                publish:
-#                    report_body: <% $.construct_report_body.stdout %>
-#                on-success:
-#                    - run_sisyphus_quick_report
-#
-#            run_sisyphus_quick_report:
-#                action: core.http
-#                input:
-#                    url: "http://<% $.host %>:<% $.siswrap_service_port %>/api/1.0/report/run/<% $.runfolder_name %>"
-#                    method: "POST"
-#                    headers: "Content-Type=application/json"
-#                    body: <% $.report_body %>
-#                publish:
-#                    report_status_url: "<% $.run_sisyphus_quick_report.body.link %>"
-#                on-success:
-#                    - poll_report_status
-#
-#            poll_report_status:
-#                action: arteria-packs.poll_status
-#                input:
-#                    url: "<% $.report_status_url %>"
-#                on-success:
-#                    - download_qc_config
-#            ### QUICK REPORT END ###
-#
-#            ### QUALITY CONTROL START ###
-#            download_qc_config:
-#                action: core.http
-#                input:
-#                    url: <% $.hermes_base_url %>/<% $.flowcell_name %>/qcfile
-#                    headers: USER=<% $.hermes_user %>&X-XSRF-TOKEN=<% $.hermes_token %>
-#                publish:
-#                    qc_conf_string: <% $.download_qc_config.body.qc %>
-#                on-success:
-#                    - construct_qc_body
-#
-#            construct_qc_body:
-#                action: arteria-packs.parse_siswrap_args
-#                input:
-#                    runfolder: "<% $.runfolder_name %>"
-#                    qc_config: "<% $.qc_conf_string %>"
-#                publish:
-#                    qc_body: <% $.construct_qc_body.stdout %>
-#                on-success:
-#                    - run_sisyphus_qc
-#
-#            run_sisyphus_qc:
-#                action: core.http
-#                input:
-#                    url: "http://<% $.host %>:<% $.siswrap_service_port %>/api/1.0/qc/run/<% $.runfolder_name %>"
-#                    method: "POST"
-#                    headers: "Content-Type=application/json"
-#                    body: <% $.qc_body %>
-#                publish:
-#                    qc_status_url: "<% $.run_sisyphus_qc.body.link %>"
-#                on-success:
-#                    - poll_qc_status
-#
-#            poll_qc_status:
-#                action: arteria-packs.poll_status
-#                input:
-#                    url: <% $.qc_status_url %>
-#               on-success:
-#                    - rsync_to_summary_host
-#                on-error:
-#                    # When we choose to ignore the sisphus qc rsults, just move on
-#                    # otherwise mark as failed and notify.
-#                    - rsync_to_summary_host: <% $.ignore_sisyphus_qc_result %>
-#                    - mark_as_failed: <% not $.ignore_sisyphus_qc_result %>
-#                    - oh_shit_error: <% not $.ignore_sisyphus_qc_result %>
-#            ### QUALITY CONTROL END ###
+            download_samplesheet:
+                action: core.http
+                input:
+                    url: <% $.hermes_base_url %>/<% $.flowcell_name %>/samplesheetfile
+                    headers: USER=<% $.hermes_user %>&X-XSRF-TOKEN=<% $.hermes_token %>
+                publish:
+                    samplesheet_string: <% $.download_samplesheet.body.samplesheet %>
+                on-success:
+                    - construct_bcl2fastq_body
+
+            # Since we don't want to pass empty values into
+            # bcl2fastq-ws, we remove any empty keys from
+            # this body.
+            construct_bcl2fastq_body:
+                action: arteria-packs.parse_bcl2fastq_args
+                input:
+                    samplesheet: "<% $.samplesheet_string %>"
+                    bcl2fastq_version: "<% $.bcl2fastq_version %>"
+                    barcode_mismatches: "<% $.barcode_mismatches %>"
+                    tiles: "<% $.tiles %>"
+                    use_base_mask: "<% $.use_base_mask %>"
+                    additional_arguments: "<% $.bcl2fastq_additional_arguments %>"
+                publish:
+                    bcl2fastq_body: <% $.construct_bcl2fastq_body.stdout %>
+                on-success:
+                    - run_bcl2fastq
+
+            run_bcl2fastq:
+                action: core.http
+                input:
+                    url: "http://<% $.host %>:<% $.bcl2fastq_service_port %>/api/1.0/start/<% $.runfolder_name %>"
+                    method: "POST"
+                    headers: "Content-Type=application/json"
+                    body: <% $.bcl2fastq_body %>
+                publish:
+                    bcl2fastq_status_url: <% $.run_bcl2fastq.body.link %>
+                on-success:
+                    - poll_demultiplex_status
+
+            poll_demultiplex_status:
+                action: arteria-packs.poll_status
+                input:
+                    url: <% $.bcl2fastq_status_url %>
+                    timeout: 86400 # Wait for 24 h before timing out.
+                on-success:
+                    - download_sisyphus_config
+            ## DEMULTIPLEX END ###
+            ### QUICK REPORT START ###
+            download_sisyphus_config:
+                action: core.http
+                input:
+                    url: <% $.hermes_base_url %>/<% $.flowcell_name %>/configfile
+                    headers: USER=<% $.hermes_user %>&X-XSRF-TOKEN=<% $.hermes_token %>
+                publish:
+                    sisyphus_conf_string: <% $.download_sisyphus_config.body.config %>
+                on-success:
+                    - construct_report_body
+
+            construct_report_body:
+                action: arteria-packs.parse_siswrap_args
+                input:
+                    runfolder: "<% $.runfolder_name %>"
+                    sisyphus_config: "<% $.sisyphus_conf_string %>"
+                publish:
+                    report_body: <% $.construct_report_body.stdout %>
+                on-success:
+                    - run_sisyphus_quick_report
+
+            run_sisyphus_quick_report:
+                action: core.http
+                input:
+                    url: "http://<% $.host %>:<% $.siswrap_service_port %>/api/1.0/report/run/<% $.runfolder_name %>"
+                    method: "POST"
+                    headers: "Content-Type=application/json"
+                    body: <% $.report_body %>
+                publish:
+                    report_status_url: "<% $.run_sisyphus_quick_report.body.link %>"
+                on-success:
+                    - poll_report_status
+
+            poll_report_status:
+                action: arteria-packs.poll_status
+                input:
+                    url: "<% $.report_status_url %>"
+                on-success:
+                    - download_qc_config
+            ### QUICK REPORT END ###
+
+            ### QUALITY CONTROL START ###
+            download_qc_config:
+                action: core.http
+                input:
+                    url: <% $.hermes_base_url %>/<% $.flowcell_name %>/qcfile
+                    headers: USER=<% $.hermes_user %>&X-XSRF-TOKEN=<% $.hermes_token %>
+                publish:
+                    qc_conf_string: <% $.download_qc_config.body.qc %>
+                on-success:
+                    - construct_qc_body
+
+            construct_qc_body:
+                action: arteria-packs.parse_siswrap_args
+                input:
+                    runfolder: "<% $.runfolder_name %>"
+                    qc_config: "<% $.qc_conf_string %>"
+                publish:
+                    qc_body: <% $.construct_qc_body.stdout %>
+                on-success:
+                    - run_sisyphus_qc
+
+            run_sisyphus_qc:
+                action: core.http
+                input:
+                    url: "http://<% $.host %>:<% $.siswrap_service_port %>/api/1.0/qc/run/<% $.runfolder_name %>"
+                    method: "POST"
+                    headers: "Content-Type=application/json"
+                    body: <% $.qc_body %>
+                publish:
+                    qc_status_url: "<% $.run_sisyphus_qc.body.link %>"
+                on-success:
+                    - poll_qc_status
+
+            poll_qc_status:
+                action: arteria-packs.poll_status
+                input:
+                    url: <% $.qc_status_url %>
+               on-success:
+                    - rsync_to_summary_host
+                on-error:
+                    # When we choose to ignore the sisphus qc rsults, just move on
+                    # otherwise mark as failed and notify.
+                    - rsync_to_summary_host: <% $.ignore_sisyphus_qc_result %>
+                    - mark_as_failed: <% not $.ignore_sisyphus_qc_result %>
+                    - oh_shit_error: <% not $.ignore_sisyphus_qc_result %>
+            ### QUALITY CONTROL END ###
 
             ### TRANSFER FILES TO UPPMAX START ###
             rsync_to_summary_host:

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -58,7 +58,7 @@ workflows:
               action: core.http
               input:               
                 url: http://<% $.host %>:<% $.runfolder_service_port %>/api/1.0/runfolders/path<% $.runfolder %>
-                body: '{"state": "STARTED"}'
+                body: '{"state": "started"}'
                 method: "POST"
               on-success:
                 - get_runfolder_name
@@ -79,143 +79,144 @@ workflows:
                 publish:
                     flowcell_name: <% $.get_flowcell_name.result %>
                 on-success:
-                    - download_samplesheet
+                    #- download_samplesheet
+                    - rsync_to_summary_host
             ### GENERAL TASKS END ###
             ### DEMULTIPLEX START ###
-            download_samplesheet:
-                action: core.http
-                input:
-                    url: <% $.hermes_base_url %>/<% $.flowcell_name %>/samplesheetfile
-                    headers: USER=<% $.hermes_user %>&X-XSRF-TOKEN=<% $.hermes_token %>
-                publish:
-                    samplesheet_string: <% $.download_samplesheet.body.samplesheet %>
-                on-success:
-                    - construct_bcl2fastq_body
-
-            # Since we don't want to pass empty values into
-            # bcl2fastq-ws, we remove any empty keys from
-            # this body.
-            construct_bcl2fastq_body:
-                action: arteria-packs.parse_bcl2fastq_args
-                input:
-                    samplesheet: "<% $.samplesheet_string %>"
-                    bcl2fastq_version: "<% $.bcl2fastq_version %>"
-                    barcode_mismatches: "<% $.barcode_mismatches %>"
-                    tiles: "<% $.tiles %>"
-                    use_base_mask: "<% $.use_base_mask %>"
-                    additional_arguments: "<% $.bcl2fastq_additional_arguments %>"
-                publish:
-                    bcl2fastq_body: <% $.construct_bcl2fastq_body.stdout %>
-                on-success:
-                    - run_bcl2fastq
-
-            run_bcl2fastq:
-                action: core.http
-                input:
-                    url: "http://<% $.host %>:<% $.bcl2fastq_service_port %>/api/1.0/start/<% $.runfolder_name %>"
-                    method: "POST"
-                    headers: "Content-Type=application/json"
-                    body: <% $.bcl2fastq_body %>
-                publish:
-                    bcl2fastq_status_url: <% $.run_bcl2fastq.body.link %>
-                on-success:
-                    - poll_demultiplex_status
-
-            poll_demultiplex_status:
-                action: arteria-packs.poll_status
-                input:
-                    url: <% $.bcl2fastq_status_url %>
-                    timeout: 86400 # Wait for 24 h before timing out.
-                on-success:
-                    - download_sisyphus_config
-            ## DEMULTIPLEX END ###
-            ### QUICK REPORT START ###
-            download_sisyphus_config:
-                action: core.http
-                input:
-                    url: <% $.hermes_base_url %>/<% $.flowcell_name %>/configfile
-                    headers: USER=<% $.hermes_user %>&X-XSRF-TOKEN=<% $.hermes_token %>
-                publish:
-                    sisyphus_conf_string: <% $.download_sisyphus_config.body.config %>
-                on-success:
-                    - construct_report_body
-
-            construct_report_body:
-                action: arteria-packs.parse_siswrap_args
-                input:
-                    runfolder: "<% $.runfolder_name %>"
-                    sisyphus_config: "<% $.sisyphus_conf_string %>"
-                publish:
-                    report_body: <% $.construct_report_body.stdout %>
-                on-success:
-                    - run_sisyphus_quick_report
-
-            run_sisyphus_quick_report:
-                action: core.http
-                input:
-                    url: "http://<% $.host %>:<% $.siswrap_service_port %>/api/1.0/report/run/<% $.runfolder_name %>"
-                    method: "POST"
-                    headers: "Content-Type=application/json"
-                    body: <% $.report_body %>
-                publish:
-                    report_status_url: "<% $.run_sisyphus_quick_report.body.link %>"
-                on-success:
-                    - poll_report_status
-
-            poll_report_status:
-                action: arteria-packs.poll_status
-                input:
-                    url: "<% $.report_status_url %>"
-                on-success:
-                    - download_qc_config
-            ### QUICK REPORT END ###
-
-            ### QUALITY CONTROL START ###
-            download_qc_config:
-                action: core.http
-                input:
-                    url: <% $.hermes_base_url %>/<% $.flowcell_name %>/qcfile
-                    headers: USER=<% $.hermes_user %>&X-XSRF-TOKEN=<% $.hermes_token %>
-                publish:
-                    qc_conf_string: <% $.download_qc_config.body.qc %>
-                on-success:
-                    - construct_qc_body
-
-            construct_qc_body:
-                action: arteria-packs.parse_siswrap_args
-                input:
-                    runfolder: "<% $.runfolder_name %>"
-                    qc_config: "<% $.qc_conf_string %>"
-                publish:
-                    qc_body: <% $.construct_qc_body.stdout %>
-                on-success:
-                    - run_sisyphus_qc
-
-            run_sisyphus_qc:
-                action: core.http
-                input:
-                    url: "http://<% $.host %>:<% $.siswrap_service_port %>/api/1.0/qc/run/<% $.runfolder_name %>"
-                    method: "POST"
-                    headers: "Content-Type=application/json"
-                    body: <% $.qc_body %>
-                publish:
-                    qc_status_url: "<% $.run_sisyphus_qc.body.link %>"
-                on-success:
-                    - poll_qc_status
-
-            poll_qc_status:
-                action: arteria-packs.poll_status
-                input:
-                    url: <% $.qc_status_url %>
-                on-success:
-                    - rsync_to_summary_host
-                on-error:
-                    # When we choose to ignore the sisphus qc rsults, just move on
-                    # otherwise mark as failed and notify.
-                    - rsync_to_summary_host: <% $.ignore_sisyphus_qc_result %>
-                    - mark_as_failed: <% not $.ignore_sisyphus_qc_result %>
-                    - oh_shit_error: <% not $.ignore_sisyphus_qc_result %>
-            ### QUALITY CONTROL END ###
+#            download_samplesheet:
+#                action: core.http
+#                input:
+#                    url: <% $.hermes_base_url %>/<% $.flowcell_name %>/samplesheetfile
+#                    headers: USER=<% $.hermes_user %>&X-XSRF-TOKEN=<% $.hermes_token %>
+#                publish:
+#                    samplesheet_string: <% $.download_samplesheet.body.samplesheet %>
+#                on-success:
+#                    - construct_bcl2fastq_body
+#
+#            # Since we don't want to pass empty values into
+#            # bcl2fastq-ws, we remove any empty keys from
+#            # this body.
+#            construct_bcl2fastq_body:
+#                action: arteria-packs.parse_bcl2fastq_args
+#                input:
+#                    samplesheet: "<% $.samplesheet_string %>"
+#                    bcl2fastq_version: "<% $.bcl2fastq_version %>"
+#                    barcode_mismatches: "<% $.barcode_mismatches %>"
+#                    tiles: "<% $.tiles %>"
+#                    use_base_mask: "<% $.use_base_mask %>"
+#                    additional_arguments: "<% $.bcl2fastq_additional_arguments %>"
+#                publish:
+#                    bcl2fastq_body: <% $.construct_bcl2fastq_body.stdout %>
+#                on-success:
+#                    - run_bcl2fastq
+#
+#            run_bcl2fastq:
+#                action: core.http
+#                input:
+#                    url: "http://<% $.host %>:<% $.bcl2fastq_service_port %>/api/1.0/start/<% $.runfolder_name %>"
+#                    method: "POST"
+#                    headers: "Content-Type=application/json"
+#                    body: <% $.bcl2fastq_body %>
+#                publish:
+#                    bcl2fastq_status_url: <% $.run_bcl2fastq.body.link %>
+#                on-success:
+#                    - poll_demultiplex_status
+#
+#            poll_demultiplex_status:
+#                action: arteria-packs.poll_status
+#                input:
+#                    url: <% $.bcl2fastq_status_url %>
+#                    timeout: 86400 # Wait for 24 h before timing out.
+#                on-success:
+#                    - download_sisyphus_config
+#            ## DEMULTIPLEX END ###
+#            ### QUICK REPORT START ###
+#            download_sisyphus_config:
+#                action: core.http
+#                input:
+#                    url: <% $.hermes_base_url %>/<% $.flowcell_name %>/configfile
+#                    headers: USER=<% $.hermes_user %>&X-XSRF-TOKEN=<% $.hermes_token %>
+#                publish:
+#                    sisyphus_conf_string: <% $.download_sisyphus_config.body.config %>
+#                on-success:
+#                    - construct_report_body
+#
+#            construct_report_body:
+#                action: arteria-packs.parse_siswrap_args
+#                input:
+#                    runfolder: "<% $.runfolder_name %>"
+#                    sisyphus_config: "<% $.sisyphus_conf_string %>"
+#                publish:
+#                    report_body: <% $.construct_report_body.stdout %>
+#                on-success:
+#                    - run_sisyphus_quick_report
+#
+#            run_sisyphus_quick_report:
+#                action: core.http
+#                input:
+#                    url: "http://<% $.host %>:<% $.siswrap_service_port %>/api/1.0/report/run/<% $.runfolder_name %>"
+#                    method: "POST"
+#                    headers: "Content-Type=application/json"
+#                    body: <% $.report_body %>
+#                publish:
+#                    report_status_url: "<% $.run_sisyphus_quick_report.body.link %>"
+#                on-success:
+#                    - poll_report_status
+#
+#            poll_report_status:
+#                action: arteria-packs.poll_status
+#                input:
+#                    url: "<% $.report_status_url %>"
+#                on-success:
+#                    - download_qc_config
+#            ### QUICK REPORT END ###
+#
+#            ### QUALITY CONTROL START ###
+#            download_qc_config:
+#                action: core.http
+#                input:
+#                    url: <% $.hermes_base_url %>/<% $.flowcell_name %>/qcfile
+#                    headers: USER=<% $.hermes_user %>&X-XSRF-TOKEN=<% $.hermes_token %>
+#                publish:
+#                    qc_conf_string: <% $.download_qc_config.body.qc %>
+#                on-success:
+#                    - construct_qc_body
+#
+#            construct_qc_body:
+#                action: arteria-packs.parse_siswrap_args
+#                input:
+#                    runfolder: "<% $.runfolder_name %>"
+#                    qc_config: "<% $.qc_conf_string %>"
+#                publish:
+#                    qc_body: <% $.construct_qc_body.stdout %>
+#                on-success:
+#                    - run_sisyphus_qc
+#
+#            run_sisyphus_qc:
+#                action: core.http
+#                input:
+#                    url: "http://<% $.host %>:<% $.siswrap_service_port %>/api/1.0/qc/run/<% $.runfolder_name %>"
+#                    method: "POST"
+#                    headers: "Content-Type=application/json"
+#                    body: <% $.qc_body %>
+#                publish:
+#                    qc_status_url: "<% $.run_sisyphus_qc.body.link %>"
+#                on-success:
+#                    - poll_qc_status
+#
+#            poll_qc_status:
+#                action: arteria-packs.poll_status
+#                input:
+#                    url: <% $.qc_status_url %>
+#               on-success:
+#                    - rsync_to_summary_host
+#                on-error:
+#                    # When we choose to ignore the sisphus qc rsults, just move on
+#                    # otherwise mark as failed and notify.
+#                    - rsync_to_summary_host: <% $.ignore_sisyphus_qc_result %>
+#                    - mark_as_failed: <% not $.ignore_sisyphus_qc_result %>
+#                    - oh_shit_error: <% not $.ignore_sisyphus_qc_result %>
+#            ### QUALITY CONTROL END ###
 
             ### TRANSFER FILES TO UPPMAX START ###
             rsync_to_summary_host:
@@ -272,9 +273,9 @@ workflows:
                     runfolder: <% $.runfolder %>
                     runfolder_name: <% $.runfolder_name %>
                     source_host: <% $.host %>
-                    source_user: "funk_901"
-                    destination_host: "irma.uppmax.uu.se"
-                    destination_user: <% $.remote_user %>
+                    source_user: "arteria"
+                    destination_host: "irma2.uppmax.uu.se"
+                    destination_user: "funk_901"
                     destination_path: <% $.irma_remote_path %>
                     rsync_include_file: /etc/arteria/misc/hiseq.rsync
                     md5_output_file: "ngi.md5"
@@ -343,13 +344,13 @@ workflows:
               action: core.http
               input:
                 url: http://<% $.host %>:<% $.runfolder_service_port %>/api/1.0/runfolders/path<% $.runfolder %>
-                body: '{"state": "DONE"}'
+                body: '{"state": "done"}'
                 method: "POST"
 
             mark_as_failed:
               action: core.http
               input:
                 url: http://<% $.host %>:<% $.runfolder_service_port %>/api/1.0/runfolders/path<% $.runfolder %>
-                body: '{"state": "ERROR"}'
+                body: '{"state": "error"}'
                 method: "POST"
             ### NOTIFIER END ###

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -49,6 +49,7 @@ workflows:
                 send_mail_to: <% $.get_config.result.send_mail_to %>
                 remote_sisyphus_location: <% $.get_config.result.remote_sisyphus_location %>
                 nestor_remote_path: <% $.get_config.result.nestor_remote_path %>
+                irma_remote_path: <% $.get_config.result.irma_remote_path %>
                 ngi_pipeline_url: <% $.get_config.result.ngi_pipeline_url %>
               on-success:
                  - mark_as_started
@@ -236,10 +237,10 @@ workflows:
                     url: <% $.hermes_base_url %>/<% $.flowcell_name %>/flowcell/analysishostinfo
                     headers: USER=<% $.hermes_user %>&X-XSRF-TOKEN=<% $.hermes_token %>
                on-success:
-                    - rsync_to_uppmax
-                    - rsync_to_nestor: <% 'nestor.uppmax.uu.se' in $.check_hosts_to_rsync_to.body.remote_hosts %>
+                    - rsync_to_milou: <% 'milou-b.uppmax.uu.se' in $.check_hosts_to_rsync_to.body.remote_hosts %>
+                    - rsync_to_irma: <% 'irma.uppmax.uu.se' in $.check_hosts_to_rsync_to.body.remote_hosts %>
 
-            rsync_to_uppmax:
+            rsync_to_milou:
                 action: arteria-packs.sync_workflow
                 input:
                     runfolder: <% $.runfolder %>
@@ -252,39 +253,54 @@ workflows:
                     rsync_include_file: /etc/arteria/misc/hiseq.rsync
                     md5_output_file: "checksums.md5"
                 on-success:
-                    - start_aeacus_stats
+                    - milou_check_md5sums
 
-            rsync_to_nestor:
+            milou_check_md5sums:
+                action: core.remote
+                input:
+                    hosts: <% $.remote_host %>
+                    username: <% $.remote_user %>
+                    cwd: <% $.remote_destination %>
+                    cmd: md5sum -c  <% $.remote_destination %>/<% $.runfolder_name %>/MD5/checksums.md5
+                    timeout: 86400 # 24 h timeout
+                on-success:
+                    - milou_start_aeacus_stats
+
+            rsync_to_irma:
                 action: arteria-packs.sync_workflow
                 input:
                     runfolder: <% $.runfolder %>
                     runfolder_name: <% $.runfolder_name %>
                     source_host: <% $.host %>
-                    source_user: "arteria"
-                    destination_host: "nestor.uppmax.uu.se"
+                    source_user: "funk_901"
+                    destination_host: "irma.uppmax.uu.se"
                     destination_user: <% $.remote_user %>
-                    destination_path: <% $.nestor_remote_path %>
-                    rsync_include_file: /etc/arteria/misc/ngi.rsync
+                    destination_path: <% $.irma_remote_path %>
+                    rsync_include_file: /etc/arteria/misc/hiseq.rsync
                     md5_output_file: "ngi.md5"
                 on-success:
-                  - start_ngi_pipeline
+                  - mark_as_finished
+                  - notify_finished
+
+            # TODO Need to add checksum verification on irma
+            # TODO Need to add starting the ngi pipeline on irma
 
             ### TRANSFER FILES TO UPPMAX END ###
 
             ### START AEACUS REPORT STEPS ###
-            start_aeacus_stats:
+            milou_start_aeacus_stats:
                 action: core.remote
                 input:
                     hosts: <% $.remote_host %>
                     username: <% $.remote_user %>
                     cwd: <% $.remote_destination %>/<% $.runfolder_name %>
                     cmd: <% $.remote_sisyphus_location %>/aeacus-stats.pl -runfolder <% $.remote_destination %>/<% $.runfolder_name %>
-                    env: 
+                    env:
                         PERL5LIB: /proj/a2009002/perl/lib/perl5/
                 on-success:
-                    - start_aeacus_report
+                    - milou_start_aeacus_report
 
-            start_aeacus_report:
+            milou_start_aeacus_report:
                 action: core.remote
                 input:
                     hosts: <% $.remote_host %>
@@ -299,10 +315,11 @@ workflows:
             ## START AEACUS REPORT STEPS END ###
 
             ## START NGI_PIPELINE IF NECESSARY ##
-            start_ngi_pipeline:
-              action: core.http
-              input:
-                url: <% $.ngi_pipeline_url %>/<% $.runfolder_name %>
+            # TODO Make sure to setup new URL for ngi_pipeline
+            #start_ngi_pipeline:
+            #  action: core.http
+            #  input:
+            #    url: <% $.ngi_pipeline_url %>/<% $.runfolder_name %>
             ## END START NGI_PIPELINE ##
 
             ## NOTIFIER START ###

--- a/actions/workflows/sync_workflow.yaml
+++ b/actions/workflows/sync_workflow.yaml
@@ -47,7 +47,7 @@ workflows:
                 input:
                     source: <% $.runfolder %>
                     source_host: <% $.source_host %>
-                    source_host_user: "arteria"
+                    source_host_user: <% $.source_user %>
                     dest_server: <% $.destination_host %>
                     dest_user: <% $.destination_user %>
                     destination: <% $.destination_path %>

--- a/actions/workflows/sync_workflow.yaml
+++ b/actions/workflows/sync_workflow.yaml
@@ -64,16 +64,5 @@ workflows:
                     dest_server: <% $.destination_host %>
                     dest_user: <% $.destination_user %>
                     destination: <% $.destination_path %>/<% $.runfolder_name %>/
-                on-success:
-                    - check_md5sums
-
-            check_md5sums:
-                action: core.remote
-                input:
-                    hosts: <% $.destination_host %>
-                    username: <% $.destination_user %>
-                    cwd: <% $.destination_path %>
-                    cmd: md5sum -c <% $.destination_path %>/<% $.runfolder_name %>/MD5/<% $.md5_output_file %>
-                    timeout: 86400 # 24 h timeout
 
             ### TRANSFER FILES END ###

--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ remote_destination: /tmp/runfolders/
 remote_sisyphus_location: /opt/arteria/arteria-siswrap-env/deps/sisyphus/sisyphus-latest
 
 ngi_pipeline_url: http://nestor1.uppmax.uu.se:6666/test_flowcell_analysis
-nestor_remote_path: /home/joda8933/test_runfolders
+irma_remote_path: ./staging/
 
 send_mail_to: example.mail.address@send.errors.to
 

--- a/scripts/create_dot_graph.py
+++ b/scripts/create_dot_graph.py
@@ -1,0 +1,58 @@
+
+import yaml
+import sys
+import argparse
+from graphviz import Digraph
+
+
+def add_edges(dot, look_up_key, task_name, task):
+    on_success_key = look_up_key
+    if on_success_key not in task:
+        pass
+    else:
+        dependencies = task[on_success_key]
+        for elem in dependencies:
+            # If a part of the workflow branches in mistral
+            # this will be represented as a list of dict.
+            # That is the reason for this somewhat ugly check.
+            if type(elem) is dict:
+                for key in elem:
+                    dot.edge(task_name, key, label=elem[key])
+            else:
+                dot.edge(task_name, elem)
+
+
+def add_success_edges(dot, task_name, task):
+    add_edges(dot, "on-success", task_name, task)
+
+
+def add_error_edges(dot, task_name, task):
+    add_edges(dot, "on-error", task_name, task)
+
+
+def main(argv):
+
+    parser = argparse.ArgumentParser(description='Create a dot representation of the give mistral workflow file')
+    parser.add_argument('--file', required=True, help='Path to workflow file')
+    parser.add_argument('--output', required=True, help='Path to output file')
+    parser.add_argument('--format', required=False, help='Format of output file', default="png")
+
+    args = parser.parse_args()
+
+    with open(args.file, "r") as f:
+        workflow = yaml.load(f)
+
+    tasks = workflow["workflows"]["main"]["tasks"]
+
+    dot = Digraph(comment='Workflow description', format=args.format)
+    for key in tasks:
+        task = tasks[key]
+        dot.node(key)
+        add_success_edges(dot, key, task)
+        add_error_edges(dot, key, task)
+
+    dot.render(args.output)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/sensors/runfolder_client.py
+++ b/sensors/runfolder_client.py
@@ -19,7 +19,7 @@ class RunfolderClient():
         for host in self._hosts:
             # TODO: Add packs id to log in a generic way
             self._logger.info("Querying {0}".format(host))
-            url = "{0}/api/1.0/runfolders/next".format(host)
+            url = "{0}/api/1.0/runfolders/pickup".format(host)
             try:
                 resp = requests.get(url)
                 if resp.status_code != 200:


### PR DESCRIPTION
This pull request ensures that the workflow:
 - can rsync to irma
 - state is harmonized with version v1.1.0 of the `arteria-runfolder` service
 - that picking up runfolders from the `arteria-runfolder` service is done through the new `pickup` endpoint.

It also: 
 - makes the `poll_status.py` script retry failed connections, hopefully making it a bit more robust to minor network issues.
 - Adds `create_dot_graph.py` - a small script that can create a graphical representation of the workflow in dot format. Useful for documentation purposes.

