### PR TITLE
Make fill-projman workflow conform to Stackstorm v2

### DIFF
--- a/actions/workflows/fill_projman.yaml
+++ b/actions/workflows/fill_projman.yaml
@@ -44,6 +44,7 @@ workflows:
                 directory: <% $.summary_destination %>/<% $.current_year %>/
                 username: <% $.summary_user %>
                 hosts: <% $.summary_host %>
+                private_key: <% $.summary_host_key %>
               publish:
                 runfolders: <% task(check_for_runfolders).result.get($.summary_host).stdout %>
               on-success:
@@ -75,6 +76,7 @@ workflows:
                 directory: <% $.summary_destination %>/<% $.current_year %>/
                 username: <% $.summary_user %>
                 hosts: <% $.summary_host %>
+                private_key: <% $.summary_host_key %>
                 # Require the summary report file to be at least 20 min old.
                 # This avoids trying to read a report into the db
                 # for which the report job has not yet been finished.

--- a/actions/workflows/fill_projman.yaml
+++ b/actions/workflows/fill_projman.yaml
@@ -22,6 +22,7 @@ workflows:
               publish:
                 summary_host: <% task(get_config).result.result.summary_host %>
                 summary_user: <% task(get_config).result.result.summary_user %>
+                summary_host_key: <% task(get_config).result.result.summary_host_key %>
                 summary_destination: <% task(get_config).result.result.summary_destination %>
                 irma_remote_path: <% task(get_config).result.result.irma_remote_path %>
               on-success:
@@ -64,6 +65,7 @@ workflows:
                 cmd: rsync -e "ssh -i /home/seqsum/.ssh/mm-xlas002" -r --times funk_901@irma1.uppmax.uu.se:<% $.irma_remote_path %>/<% $.runfolder %>/Summary <% $.summary_destination %>/<% $.current_year %>/<% $.runfolder %>/; if (( $? == 0 || $? == 23 )) ; then true; else false; fi
                 hosts: <% $.summary_host %>
                 username: <% $.summary_user %>
+                private_key: <% $.summary_host_key %>
               on-complete:
                 - check_reports_old_enough
 
@@ -90,4 +92,5 @@ workflows:
                 cwd: /home/seqsum
                 username: <% $.summary_user %>
                 hosts: <% $.summary_host %>
+                private_key: <% $.summary_host_key %>
 

--- a/config.yaml
+++ b/config.yaml
@@ -6,11 +6,12 @@ hermes_token: my_token
 
 summary_host: testuppmax
 summary_user: arteria
+summary_host_key: /path/to/ssh/key
 summary_destination: /tmp/summaries/
 
 remote_host: testuppmax
 remote_user: arteria
-remote_host_key:/path/to/ssh/key 
+remote_host_key: /path/to/ssh/key
 remote_destination: /tmp/runfolders/
 remote_sisyphus_location: /opt/arteria/arteria-siswrap-env/deps/sisyphus/sisyphus-latest
 


### PR DESCRIPTION
For the fill-projman workflow to work with Stackstorm v2 we need to pass the `private_key` argument to our `core.remote` and `remote-shell-script` actions (even though I thought it wasn't necessary for the latter according to the docs...). 

This branch has now been tested to work OK in staging at least. 

