### PR TITLE
Get ngi pipeline reports

### DIFF
--- a/actions/gather_ngi_pipeline_reports.yaml
+++ b/actions/gather_ngi_pipeline_reports.yaml
@@ -1,0 +1,16 @@
+---
+name: gather_ngi_pipeline_reports
+description: Downloads the ngi pipeline reports to the summary host
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/gather_ngi_pipeline_reports.yaml
+pack: arteria-packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: arteria-packs.gather_ngi_pipeline_reports
+    immutable: true
+    type: string

--- a/actions/workflows/gather_ngi_pipeline_reports.yaml
+++ b/actions/workflows/gather_ngi_pipeline_reports.yaml
@@ -1,0 +1,36 @@
+version: "2.0" # mistral version
+name: arteria-packs.gather_ngi_pipeline_reports
+description: Downloads ngi pipeline reports from e.g. irma to our summary host.
+
+workflows:
+    main:
+        type: direct
+
+        tasks:
+            note_workflow_version:
+              action: core.local
+              input:
+                cmd: git rev-parse HEAD
+                cwd: /opt/stackstorm/packs/arteria-packs/
+              on-success:
+                  - get_config
+
+            get_config:
+              action: arteria-packs.get_pack_config
+              publish:
+                summary_host: <% task(get_config).result.result.summary_host %>
+                summary_user: <% task(get_config).result.result.summary_user %>
+                summary_destination: <% task(get_config).result.result.summary_destination %>
+                irma_reports_remote_path: <% task(get_config).result.result.irma_reports_remote_path %>
+                summary_host_key: <% task(get_config).result.result.summary_host_key %>
+              on-success:
+                - rsync_from_irma
+
+            rsync_from_irma:
+              action: core.remote
+              input:
+                cmd: rsync -e "ssh -i /home/seqsum/.ssh/mm-xlas002" -r funk_901@irma1.uppmax.uu.se:<% $.irma_reports_remote_path %>/ <% $.summary_destination %>/
+                hosts: <% $.summary_host %>
+                username: <% $.summary_user %>
+                private_key: <% $.summary_host_key %>
+

--- a/actions/workflows/gather_ngi_pipeline_reports.yaml
+++ b/actions/workflows/gather_ngi_pipeline_reports.yaml
@@ -20,7 +20,7 @@ workflows:
               publish:
                 summary_host: <% task(get_config).result.result.summary_host %>
                 summary_user: <% task(get_config).result.result.summary_user %>
-                summary_destination: <% task(get_config).result.result.summary_destination %>
+                summary_ngi_pipeline_reports_destination: <% task(get_config).result.result.summary_ngi_pipeline_reports_destination %>
                 irma_reports_remote_path: <% task(get_config).result.result.irma_reports_remote_path %>
                 summary_host_key: <% task(get_config).result.result.summary_host_key %>
               on-success:
@@ -29,7 +29,7 @@ workflows:
             rsync_from_irma:
               action: core.remote
               input:
-                cmd: rsync -e "ssh -i /home/seqsum/.ssh/mm-xlas002" -r funk_901@irma1.uppmax.uu.se:<% $.irma_reports_remote_path %>/ <% $.summary_destination %>/
+                cmd: rsync -e "ssh -i /home/seqsum/.ssh/mm-xlas002" -r funk_901@irma1.uppmax.uu.se:<% $.irma_reports_remote_path %>/ <% $.summary_ngi_pipeline_reports_destination %>/
                 hosts: <% $.summary_host %>
                 username: <% $.summary_user %>
                 private_key: <% $.summary_host_key %>

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ summary_host: testuppmax
 summary_user: arteria
 summary_host_key: /path/to/ssh/key
 summary_destination: /tmp/summaries/
+summary_ngi_pipeline_reports_destination: /tmp/summaries/ngi_reports
 
 remote_host: testuppmax
 remote_user: arteria
@@ -19,6 +20,7 @@ ngi_pipeline_url: https://irma1.uppmax.uu.se:4444/ngi_pipeline_upps
 
 irma_api_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 irma_remote_path: ./staging/
+irma_reports_remote_path: ./staging/reports/
 irma_checksum_base_url: https://irma1.uppmax.uu.se:4444/arteria_checksum_staging/api/1.0
 irma_siswrap_base_url: https://irma1.uppmax.uu.se:4444/arteria_siswrap_staging/api/1.0
 

--- a/rules/gather_ngi_pipeline_reports.yaml
+++ b/rules/gather_ngi_pipeline_reports.yaml
@@ -8,7 +8,7 @@ trigger:
     type: "core.st2.IntervalTimer"
     parameters:
       unit: hours
-      delta: 2
+      delta: 6
 
 action:
     ref: "arteria-packs.gather_ngi_pipeline_reports"

--- a/rules/gather_ngi_pipeline_reports.yaml
+++ b/rules/gather_ngi_pipeline_reports.yaml
@@ -1,0 +1,16 @@
+---
+name: "arteria-packs.gather_ngi_pipeline_reports"
+pack: "arteria-packs"
+description: "Attempts to synchronize project reports from the ngi_pipeline at the set intervals."
+enabled: true
+
+trigger:
+    type: "core.st2.IntervalTimer"
+    parameters:
+      unit: hours
+      delta: 2
+
+action:
+    ref: "arteria-packs.gather_ngi_pipeline_reports"
+
+


### PR DESCRIPTION
This enables downloading of our ngi pipeline reports from a specific directory on irma. It introduces two new configuration values, namely: `summary_ngi_pipeline_reports_destination` and `irma_reports_remote_path`.