### PR TITLE
Bug fix: Swap read number in ConversionStats.xml

### DIFF
--- a/actions/lib/swap_read_nr_in_conversionstats.sh
+++ b/actions/lib/swap_read_nr_in_conversionstats.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e 
+
+RUNFOLDER=$1
+SWAP_FROM=$2
+SWAP_TO=$3
+
+sed -i -e "s:Read number=\"${SWAP_FROM}\":Read number=\"${SWAP_TO}\":g" ${RUNFOLDER}/Unaligned/Stats/ConversionStats.xml

--- a/actions/ngi_uu_workflow.yaml
+++ b/actions/ngi_uu_workflow.yaml
@@ -47,3 +47,15 @@ parameters:
     default: ""
     type: string
     description: "Any additional arguments to bcl2fastq can be fed here. Note that quoutes (\") are needed around arguments for the to parse properly. E.g. \"--my-first-arg 1 --my-second-arg 2\" "
+  conversionstats_swap_read_nr:
+    default: false
+    type: boolean
+    description: "Set to true to swap read numbers in Unaligned/Stats/ConversionStats.xml due to bug in bcl2fastq"
+  conversionstats_swap_read_from:
+    default: 65
+    type: integer
+    description: "What read number to replace"
+  conversionstats_swap_read_to:
+    default: 1
+    type: integer
+    description: "Value of new read number"

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -144,7 +144,7 @@ workflows:
             conversionstats_workaround:
                 action: core.local
                 input:
-                    cmd: ssh <% $.host %> sed -i -e \'s/Read number=\"<% $.conversionstats_swap_read_from %>\"/Read number=\"<% $.conversionstats_swap_read_to\"/g\' <% $.runfolder %>/Unaligned/Stats/ConversionStats.xml
+                    cmd: ssh <% $.host %> "bash -s" < /opt/stackstorm/packs/arteria-packs/actions/lib/swap_read_nr_in_conversionstats.sh <% $.runfolder %> <% $.conversionstats_swap_read_from %> <% $.conversionstats_swap_read_to %>
                 on-success:
                     - download_sisyphus_config
 

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -141,6 +141,9 @@ workflows:
                     - conversionstats_workaround: <% $.conversionstats_swap_read_nr = true %>
                     - download_sisyphus_config: <% $.conversionstats_swap_read_nr = false %>
 
+            # Due to a bug in bcl2fastq some read numbers in Unaligned/Stats/ConversionStats.xml will sometimes have the wrong number. 
+            # If the Arteria operator manually sets "conversionstats_swap_read"_nr to "true" then this workaround action will swap 
+            # the incorrect value "conversionstats_swap_read_from" to the requested correct value "conversionstats_swap_read_to". 
             conversionstats_workaround:
                 action: core.local
                 input:

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -138,8 +138,8 @@ workflows:
                     url: <% $.bcl2fastq_status_url %>
                     timeout: 86400 # Wait for 24 h before timing out.
                 on-success:
-                    - conversionstats_workaround: <% $.conversionstats_swap_read_nr == true %>
-                    - download_sisyphus_config: <% $.conversionstats_swap_read_nr == false %>
+                    - conversionstats_workaround: <% $.conversionstats_swap_read_nr = true %>
+                    - download_sisyphus_config: <% $.conversionstats_swap_read_nr = false %>
 
             conversionstats_workaround:
                 action: core.local

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -142,12 +142,12 @@ workflows:
                     - download_sisyphus_config: <% $.conversionstats_swap_read_nr == false %>
 
             conversionstats_workaround:
-                action: core.remote
+                action: core.local
                 input:
                     cmd: ssh <% $.host %> sed -i -e \'s/Read number=\"<% $.conversionstats_swap_read_from %>\"/Read number=\"<% $.conversionstats_swap_read_to\"/g\' <% $.runfolder %>/Unaligned/Stats/ConversionStats.xml
                 on-success:
                     - download_sisyphus_config
-                 
+
             milou_check_md5sums:
                 action: core.remote
                 input:

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -14,6 +14,9 @@ workflows:
             - tiles
             - use_base_mask
             - bcl2fastq_additional_arguments
+            - conversionstats_swap_read_nr
+            - conversionstats_swap_read_from
+            - conversionstats_swap_read_to
         output:
             output_the_whole_workflow_context: <% $ %>
         task-defaults:
@@ -135,7 +138,28 @@ workflows:
                     url: <% $.bcl2fastq_status_url %>
                     timeout: 86400 # Wait for 24 h before timing out.
                 on-success:
+                    - conversionstats_workaround: <% $.conversionstats_swap_read_nr == true %>
+                    - download_sisyphus_config: <% $.conversionstats_swap_read_nr == false %>
+
+            conversionstats_workaround:
+                action: core.remote
+                input:
+                    cmd: ssh <% $.host %> sed -i -e \'s/Read number=\"<% $.conversionstats_swap_read_from %>\"/Read number=\"<% $.conversionstats_swap_read_to\"/g\' <% $.runfolder %>/Unaligned/Stats/ConversionStats.xml
+                on-success:
                     - download_sisyphus_config
+                 
+            milou_check_md5sums:
+                action: core.remote
+                input:
+                    hosts: <% $.remote_host %>
+                    username: <% $.remote_user %>
+                    cwd: <% $.remote_destination %>
+                    cmd: md5sum -c  <% $.remote_destination %>/<% $.runfolder_name %>/MD5/checksums.md5
+                    timeout: 86400 # 24 h timeout
+                    private_key: <% $.remote_host_key %>
+                on-success:
+                    - milou_start_aeacus_stats
+
             ## DEMULTIPLEX END ###
             ### QUICK REPORT START ###
             download_sisyphus_config:

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -148,18 +148,6 @@ workflows:
                 on-success:
                     - download_sisyphus_config
 
-            milou_check_md5sums:
-                action: core.remote
-                input:
-                    hosts: <% $.remote_host %>
-                    username: <% $.remote_user %>
-                    cwd: <% $.remote_destination %>
-                    cmd: md5sum -c  <% $.remote_destination %>/<% $.runfolder_name %>/MD5/checksums.md5
-                    timeout: 86400 # 24 h timeout
-                    private_key: <% $.remote_host_key %>
-                on-success:
-                    - milou_start_aeacus_stats
-
             ## DEMULTIPLEX END ###
             ### QUICK REPORT START ###
             download_sisyphus_config:


### PR DESCRIPTION
Due to a bug in bcl2fastq sometimes the read number in Unaligned/Stats/ConversionStats.xml gets set to 65 instead of 1, which will cause Sisyphus to fail. When this happens the bioinformaticians want to be able to manually override the workflow and force the read number to be swapped to a more appropriate value (usually 1). 

Have tested the logic on staging server with a smaller subset of the NGI UU workflow. 