### PR TITLE
Bug fix: Archive runs destignated for Irma as well

### DIFF
--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -397,8 +397,7 @@ workflows:
                   url: <% $.irma_siswrap_base_url %>/aeacusreports/status/<% $.irma_run_aeacus_reports_job_id %>?apikey=<% $.irma_api_key %>
                   verify_ssl_cert: False
                 on-success:
-                  - notify_finished
-                  - mark_as_finished
+                  - upload_runfolder_to_pdc
 
             ### END AEACUS REPORT STEPS ###
             # TODO Need to add starting the ngi pipeline on irma


### PR DESCRIPTION
Obviously we should also archive runfolders that have been processed on Irma, and not only those that have been processed on Milou. Missed to add the call to both execution paths in previous PR. 