### PR TITLE
WIP: Delivery workflow

### DIFF
--- a/actions/arteria_delivery_service.py
+++ b/actions/arteria_delivery_service.py
@@ -14,15 +14,20 @@ class ArteriaDeliveryService(Action):
     def query_for_status(self, links):
         STAGING_SUCCESSFUL = 'staging_successful'
         STAGING_FAILED = 'staging_failed'
+        STAGING_PENDING = 'pending'
+        STAGING_IN_PROGRESS = 'staging_in_progress'
+        valid_states = [STAGING_SUCCESSFUL, STAGING_FAILED, STAGING_PENDING, STAGING_IN_PROGRESS]
 
         def update_links(links_results):
             for link, state in links_results.iteritems():
                 if state == STAGING_SUCCESSFUL or state == STAGING_FAILED:
                     continue
-                else:
+                elif state in valid_states:
                     response = requests.get(link)
                     response_as_json = json.loads(response.content)
                     links_results[link] = response_as_json["status"]
+                else:
+                    raise NotImplemented("Do not know how to handle state: {}".format(state))
 
         def is_in_end_state(link_state):
             if not link_state:

--- a/actions/arteria_delivery_service.py
+++ b/actions/arteria_delivery_service.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+import requests
+import json
+import time
+
+
+# Needs to be run in a Stackstorm virtualenv
+from st2actions.runners.pythonrunner import Action
+
+
+class ArteriaDeliveryService(Action):
+
+    def query_for_status(self, links):
+        STAGING_SUCCESSFUL = 'staging_successful'
+        STAGING_FAILED = 'staging_failed'
+
+        def update_links(links_results):
+            for link, state in links_results.iteritems():
+                if state == STAGING_SUCCESSFUL or state == STAGING_FAILED:
+                    continue
+                else:
+                    response = requests.get(link)
+                    response_as_json = json.loads(response.content)
+                    links_results[link] = response_as_json["status"]
+
+        def is_in_end_state(link_state):
+            if not link_state:
+                return False
+            else:
+                return link_state == STAGING_SUCCESSFUL or link_state == STAGING_FAILED
+
+        links_results = dict(map(lambda x: (x, None), links))
+
+        while not all(map(is_in_end_state, links_results.values())):
+            # TODO Make sleep time configurable
+            time.sleep(5)
+            update_links(links_results)
+            self.logger.info("Updated status, now have: {}".format(links_results))
+
+        return links_results
+
+    def stage_delivery(self, base_url, runfolder_name, projects):
+        url = "{}/{}/{}".format(base_url, 'api/1.0/stage/runfolder', runfolder_name)
+
+        if projects:
+            payload = {'projects': projects['projects']}
+        else:
+            payload = {}
+        headers = {'content-type': 'application/json'}
+        response = requests.post(url, data=json.dumps(payload), headers=headers)
+
+        if response.status_code != 202:
+            raise AssertionError("Delivery server did not accept staging request. "
+                                 "URL: {} with response: \n {}".format(url, response.content))
+
+        response_as_json = json.loads(response.content)
+
+        links = response_as_json['staging_order_links']
+        return links
+
+    def run(self, action, delivery_base_api_url, **kwargs):
+        if action == "stage_runfolder":
+            status_links = self.stage_delivery(delivery_base_api_url, kwargs['runfolder_name'], kwargs.get('projects'))
+            return self.query_for_status(status_links)
+        else:
+            raise AssertionError("Action: {} was not recognized.".format(action))
+

--- a/actions/arteria_delivery_service.py
+++ b/actions/arteria_delivery_service.py
@@ -8,32 +8,38 @@ import time
 # Needs to be run in a Stackstorm virtualenv
 from st2actions.runners.pythonrunner import Action
 
+class ArteriaQuerierBase(object):
 
-class ArteriaDeliveryService(Action):
+    def __init__(self, logger):
+        self.logger = logger
+
+    def valid_status(self):
+        raise NotImplementedError("Has to be implemented by inheriting class")
+
+    def successful_status(self):
+        raise NotImplementedError("Has to be implemented by inheriting class")
+
+    def failed_status(self):
+        raise NotImplementedError("Has to be implemented by inheriting class")
 
     def query_for_status(self, links):
-        STAGING_SUCCESSFUL = 'staging_successful'
-        STAGING_FAILED = 'staging_failed'
-        STAGING_PENDING = 'pending'
-        STAGING_IN_PROGRESS = 'staging_in_progress'
-        valid_states = [STAGING_SUCCESSFUL, STAGING_FAILED, STAGING_PENDING, STAGING_IN_PROGRESS]
 
         def update_links(links_results):
             for link, state in links_results.iteritems():
-                if state == STAGING_SUCCESSFUL or state == STAGING_FAILED:
+                if state == self.successful_status() or state in self.failed_status():
                     continue
-                elif state in valid_states:
+                elif state in self.valid_status() or not state:
                     response = requests.get(link)
                     response_as_json = json.loads(response.content)
                     links_results[link] = response_as_json["status"]
                 else:
-                    raise NotImplemented("Do not know how to handle state: {}".format(state))
+                    raise NotImplementedError("Do not know how to handle state: {}".format(state))
 
         def is_in_end_state(link_state):
             if not link_state:
                 return False
             else:
-                return link_state == STAGING_SUCCESSFUL or link_state == STAGING_FAILED
+                return link_state == self.successful_status() or link_state in self.failed_status()
 
         links_results = dict(map(lambda x: (x, None), links))
 
@@ -45,6 +51,65 @@ class ArteriaDeliveryService(Action):
 
         return links_results
 
+
+class ArteriaStagingQuerier(ArteriaQuerierBase):
+
+    staging_successful = 'staging_successful'
+    staging_failed = 'staging_failed'
+    staging_pending = 'pending'
+    staging_in_progress = 'staging_in_progress'
+
+    def __init__(self, logger):
+        super(ArteriaStagingQuerier, self).__init__(logger)
+
+    def successful_status(self):
+        return self.staging_successful
+
+    def failed_status(self):
+        return [self.staging_failed]
+
+    def valid_status(self):
+        valid_states = [self.staging_successful, self.staging_failed, self.staging_pending, self.staging_in_progress]
+        return valid_states
+
+
+class ArteriaDeliveryQuerier(ArteriaQuerierBase):
+
+    pending = 'pending'
+    mover_processing_delivery = 'mover_processing_delivery'
+    mover_failed_delivery = 'mover_failed_delivery'
+    delivery_in_progress = 'delivery_in_progress'
+    delivery_successful = 'delivery_successful'
+    delivery_failed = 'delivery_failed'
+
+    def __init__(self, logger):
+        super(ArteriaDeliveryQuerier, self).__init__(logger)
+
+    def successful_status(self):
+        return self.delivery_successful
+
+    def failed_status(self):
+        return [self.mover_failed_delivery, self.delivery_failed]
+
+    def valid_status(self):
+        valid_states = [self.pending, self.mover_processing_delivery, self.mover_failed_delivery,
+                        self.delivery_in_progress, self.delivery_successful, self.delivery_failed]
+        return valid_states
+
+
+class ArteriaDeliveryService(Action):
+
+    def post_to_server(self, url, payload):
+        headers = {'content-type': 'application/json'}
+        response = requests.post(url, data=json.dumps(payload), headers=headers)
+
+        if response.status_code != 202:
+            raise AssertionError("Delivery server did not accept request. "
+                                 "URL: {} with response: \n {}".format(url, response.content))
+
+        response_as_json = json.loads(response.content)
+        return response_as_json
+
     def stage_delivery(self, base_url, runfolder_name, projects):
         url = "{}/{}/{}".format(base_url, 'api/1.0/stage/runfolder', runfolder_name)
 
@@ -52,22 +117,59 @@ class ArteriaDeliveryService(Action):
             payload = {'projects': projects['projects']}
         else:
             payload = {}
-        headers = {'content-type': 'application/json'}
-        response = requests.post(url, data=json.dumps(payload), headers=headers)
 
-        if response.status_code != 202:
-            raise AssertionError("Delivery server did not accept staging request. "
-                                 "URL: {} with response: \n {}".format(url, response.content))
+        response = self.post_to_server(url, payload)
+        return response
 
-        response_as_json = json.loads(response.content)
+    def deliver(self, base_url, staging_id, delivery_project_id, md5sum_file):
+        url = '{}/{}/{}'.format(base_url, 'api/1.0/deliver/stage_id', str(staging_id))
+        payload = {'delivery_project_id': delivery_project_id}
 
-        links = response_as_json['staging_order_links']
-        return links
+        if md5sum_file:
+            payload['md5sum_file'] = md5sum_file
+
+        response = self.post_to_server(url, payload)
+        links = response['delivery_order_link']
+        return [links]
+
+    def stage_and_check_status(self, delivery_base_api_url, runfolder_name, projects):
+        response = self.stage_delivery(delivery_base_api_url,
+                                       runfolder_name,
+                                       projects)
+
+        project_and_links = response['staging_order_links']
+        status_links = project_and_links.values()
+        arteria_staging_querier = ArteriaStagingQuerier(self.logger)
+        final_status = arteria_staging_querier.query_for_status(status_links)
+        links_to_projects = {v: k for k, v in project_and_links.iteritems()}
+        projects_to_staging_ids = {}
+
+        exit_status = True
+        result = {}
+
+        for link, project in links_to_projects.iteritems():
+            status = final_status[link]
+            if not status == arteria_staging_querier.successful_status():
+                exit_status = False
+                self.logger.error('Project: {} was not successfully staged. '
+                                  'Had status: {}. Link was: '.format(project, status, link))
+            result[project] = int(link.split('/')[-1])
+
+        return exit_status, result
 
     def run(self, action, delivery_base_api_url, **kwargs):
         if action == "stage_runfolder":
-            status_links = self.stage_delivery(delivery_base_api_url, kwargs['runfolder_name'], kwargs.get('projects'))
-            return self.query_for_status(status_links)
+            return self.stage_and_check_status(delivery_base_api_url,
+                                               kwargs['runfolder_name'],
+                                               kwargs.get('projects'))
+
+        elif action == "deliver":
+            status_links = self.deliver(delivery_base_api_url,
+                                        kwargs['staging_id'],
+                                        kwargs['delivery_project_id'],
+                                        kwargs.get('md5sum_file'))
+            arteria_delivery_querier = ArteriaDeliveryQuerier(self.logger)
+            return arteria_delivery_querier.query_for_status(status_links)
         else:
             raise AssertionError("Action: {} was not recognized.".format(action))
 

--- a/actions/arteria_delivery_service.py
+++ b/actions/arteria_delivery_service.py
@@ -153,6 +153,8 @@ class ArteriaDeliveryService(Action):
                 exit_status = False
                 self.logger.error('Project: {} was not successfully staged. '
                                   'Had status: {}. Link was: '.format(project, status, link))
+            # The last part of the link contains the staging id. This is sort of a hack,
+            # but it will have to do for now. /JD 20161215
             result[project] = int(link.split('/')[-1])
 
         return exit_status, result

--- a/actions/create_delivery_project_in_supr.yaml
+++ b/actions/create_delivery_project_in_supr.yaml
@@ -1,0 +1,36 @@
+---
+name: create_delivery_project_in_super
+runner_type: run-python
+description: Create a delivery project in SUPR for the specified PI and project name
+enabled: true
+entry_point: supr.py
+parameters:
+    timeout:
+        default: 10
+    action:
+        type: string
+        required: true
+        default: create_delivery_project
+        immutable: true
+    project_name:
+        type: string
+        description: Name to use for the delivery project (Normally same as NGI internal code)
+        required: true
+    pi_id:
+        type: integer
+        description: SUPR Id of PI to create project for
+        required: true
+    supr_base_api_url:
+        type: string
+        description: Email adress to look for associated PI for.
+        required: false
+        # TODO Change to production instance?
+        default: https://disposer.c3se.chalmers.se/supr-test/api
+    api_user:
+      type: string
+      description: SUPR api user
+      required: true
+    api_key:
+      type: string
+      description: SUPR api key
+      required: true

--- a/actions/create_delivery_project_in_supr.yaml
+++ b/actions/create_delivery_project_in_supr.yaml
@@ -12,14 +12,10 @@ parameters:
         required: true
         default: create_delivery_project
         immutable: true
-    project_name:
-        type: string
-        description: Name to use for the delivery project (Normally same as NGI internal code)
+    project_names_and_ids:
+        type: object
         required: true
-    pi_id:
-        type: integer
-        description: SUPR Id of PI to create project for
-        required: true
+        description: Dictionary of project names to pi ids.
     supr_base_api_url:
         type: string
         description: Email adress to look for associated PI for.

--- a/actions/delivery_runfolder_workflow.yaml
+++ b/actions/delivery_runfolder_workflow.yaml
@@ -1,0 +1,25 @@
+---
+name: delivery_runfolder_workflow
+description: Deliver a runfolder
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/delivery_runfolder_workflow.yaml
+pack: arteria-packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: arteria-packs.delivery_runfolder_workflow
+    immutable: true
+    type: string
+  runfolder_name:
+    required: true
+    type: string
+    description: Name of the runfolder to deliver
+  projects_pi_email_file:
+    required: true
+    type: string
+    description: file containing pi emails and projects
+

--- a/actions/delivery_service_deliver.yaml
+++ b/actions/delivery_service_deliver.yaml
@@ -1,0 +1,29 @@
+---
+name: delivery_service_deliver
+runner_type: run-python
+description: Delivery a staged folder using the Arteria delivery service
+enabled: true
+entry_point: arteria_delivery_service.py
+parameters:
+    timeout:
+        default: 86400
+    action:
+        type: string
+        required: true
+        default: deliver
+        immutable: true
+    staging_id:
+        type: integer
+        description: staging id of the folder you want to deliver
+        required: true
+    delivery_project_id:
+        type: string
+        description: delivery project to make the delivery to
+        required: true
+    delivery_base_api_url:
+        type: string
+        description: url to the delivery service
+        required: true
+    md5sum_file:
+      type: string
+      description: (Optional) path to a file with md5sums for Mover to verify

--- a/actions/delivery_service_stage_runfolder.yaml
+++ b/actions/delivery_service_stage_runfolder.yaml
@@ -1,0 +1,29 @@
+---
+name: delivery_service_stage_runfolder
+runner_type: run-python
+description: Stage a runfolder through the Arteria delivery service
+enabled: true
+entry_point: arteria_delivery_service.py
+parameters:
+    timeout:
+        default: 86400
+    action:
+        type: string
+        required: true
+        default: stage_runfolder
+        immutable: true
+    runfolder_name:
+        type: string
+        description: Name of the runfolder to stage
+        required: true
+    projects:
+        type: object
+        description: projects to stage as a json object looking like this {"projects":["ABC_123"]}
+        required: true
+    project_pi_email_file:
+      type: string
+      description: path to a csv file containg project names and pi email for those projects, on the format '<project_name>\t<pi email>'
+    delivery_base_api_url:
+        type: string
+        description: url to the delivery service
+        required: true

--- a/actions/get_pi_id_for_email_from_supr.yaml
+++ b/actions/get_pi_id_for_email_from_supr.yaml
@@ -12,9 +12,9 @@ parameters:
         required: true
         default: get_id_from_email
         immutable: true
-    email:
-        type: string
-        description: Email adress to look for associated PI for.
+    project_to_email_dict:
+        type: object
+        description: dict from project to emails
         required: true
     supr_base_api_url:
         type: string

--- a/actions/get_pi_id_for_email_from_supr.yaml
+++ b/actions/get_pi_id_for_email_from_supr.yaml
@@ -1,0 +1,32 @@
+---
+name: get_pi_id_for_email_from_supr
+runner_type: run-python
+description: Get the SUPR if of PI with a given email adresss
+enabled: true
+entry_point: supr.py
+parameters:
+    timeout:
+        default: 10
+    action:
+        type: string
+        required: true
+        default: get_id_from_email
+        immutable: true
+    email:
+        type: string
+        description: Email adress to look for associated PI for.
+        required: true
+    supr_base_api_url:
+        type: string
+        description: Email adress to look for associated PI for.
+        required: false
+        # TODO Change to production instance?
+        default: https://disposer.c3se.chalmers.se/supr-test/api
+    api_user:
+      type: string
+      description: SUPR api user
+      required: true
+    api_key:
+      type: string
+      description: SUPR api key
+      required: true

--- a/actions/read_projects_email_file.py
+++ b/actions/read_projects_email_file.py
@@ -26,5 +26,5 @@ class ReadProjectsEmailFile(Action):
             self.logger.info("Projects given and projects found in file did match...")
             return True, result
         else:
-            self.logger.info("Projects given and projects found in file did not match!")
+            self.logger.error("Projects given and projects found in file did not match!")
             return False, {}

--- a/actions/read_projects_email_file.py
+++ b/actions/read_projects_email_file.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import json
+import csv
+
+# Needs to be run in a Stackstorm virtualenv
+from st2actions.runners.pythonrunner import Action
+
+
+class ReadProjectsEmailFile(Action):
+
+    def run(self, file_path, projects):
+
+        projects_list = projects['projects']
+
+        result = {}
+
+        with open(file_path) as csv_file:
+            reader = csv.DictReader(csv_file, delimiter=';')
+            for row in reader:
+                project = row['project']
+                if project in projects_list:
+                    result[project] = row['email']
+
+        if len(projects_list) == len(result.keys()):
+            self.logger.info("Projects given and projects found in file did match...")
+            return True, result
+        else:
+            self.logger.info("Projects given and projects found in file did not match!")
+            return False, {}

--- a/actions/read_projects_email_file.yaml
+++ b/actions/read_projects_email_file.yaml
@@ -1,0 +1,18 @@
+---
+name: read_projects_email_file
+runner_type: run-python
+description: Reads a csv file of projects and email
+enabled: true
+entry_point: read_projects_email_file.py
+parameters:
+    timeout:
+        default: 10
+    file_path:
+        type: string
+        description: Path to read the csv file from.
+        required: true
+    projects:
+        type: object
+        description: Projects to look for (will fail if not available)
+        required: true
+

--- a/actions/supr.py
+++ b/actions/supr.py
@@ -36,6 +36,16 @@ class Supr(Action):
         return matches[0]["id"]
 
     @staticmethod
+    def search_for_pis(project_to_email_dict, supr_base_api_url, api_user, api_key):
+        res = {}
+        for project, email in project_to_email_dict.iteritems():
+            res[project] = Supr.search_by_email(base_url=supr_base_api_url,
+                                                email=email,
+                                                user=api_user,
+                                                key=api_key)
+        return res
+
+    @staticmethod
     def create_delivery_project(base_url, ngi_project_name, pi_id, user, key):
 
         create_delivery_project_url = '{}/ngi_delivery/project/create/'.format(base_url)
@@ -72,7 +82,7 @@ class Supr(Action):
 
     def run(self, action, supr_base_api_url, api_user, api_key, **kwargs):
         if action == "get_id_from_email":
-            return self.search_by_email(supr_base_api_url, kwargs['email'], api_user, api_key)
+            return self.search_for_pis(kwargs['project_to_email_dict'], supr_base_api_url, api_user, api_key)
         elif action == 'create_delivery_project':
             return self.create_delivery_project(supr_base_api_url, kwargs['project_name'],
                                                 kwargs['pi_id'], api_user, api_key)

--- a/actions/supr.py
+++ b/actions/supr.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import requests
+import json
+
+# Needs to be run in a Stackstorm virtualenv
+from st2actions.runners.pythonrunner import Action
+
+class Supr(Action):
+
+    @staticmethod
+    def search_by_email(base_url, email, user, key):
+        search_person_url = '{}/person/search/'.format(base_url)
+        # Search case insensitive
+        params = {'email_i': email}
+        response = requests.get(search_person_url, params=params, auth=(user, key))
+
+        if response.status_code != 200:
+            raise AssertionError("Status code returned when trying to get PI id for email: "
+                                 "{} was not 200.".format(email))
+
+        response_as_json = json.loads(response.content)
+        matches = response_as_json["matches"]
+
+        if len(matches) < 1:
+            raise AssertionError("There were no hits in SUPR for email: {}".format(email))
+
+        if len(matches) > 1:
+            raise AssertionError("There we more than one hit in SUPR for email: {}".format(email))
+
+        return matches[0]["id"]
+
+    def run(self, action, email, supr_base_api_url, api_user, api_key):
+        if action == "get_id_from_email":
+            return self.search_by_email(supr_base_api_url, email, api_user, api_key)
+
+

--- a/actions/workflows/delivery_runfolder_workflow.yaml
+++ b/actions/workflows/delivery_runfolder_workflow.yaml
@@ -1,0 +1,96 @@
+version: "2.0" # mistral version
+name: arteria-packs.delivery_runfolder_workflow
+description: Deliver data from a runfolder to a SNIC delivery project
+
+workflows:
+    main:
+        type: direct
+        input:
+          - runfolder_name
+          - projects_pi_email_file
+          # TODO Later we want to make sure that we can restrict which projects should be delivered...
+          #- restrict_to_projects
+
+        # FLOW:
+        # [x] Check which projects are available for runfolder
+        # [x] Get emails for PIs for these projects
+        # [x] Get PI id for PIs in SUPr
+        # [x] Stage projects
+        # [x] Create delivery projects for PIs
+        # [] Run delivery
+
+        tasks:
+            note_workflow_version:
+              action: core.local
+              input:
+                cmd: git rev-parse HEAD
+                cwd: /opt/stackstorm/packs/arteria-packs/
+              on-success:
+                  - get_config
+
+            get_config:
+              action: arteria-packs.get_pack_config
+              publish:
+                supr_api_user: <% task(get_config).result.result.supr_api_user %>
+                supr_api_key: <% task(get_config).result.result.supr_api_key %>
+                supr_api_url: <% task(get_config).result.result.supr_api_url %>
+                supr_api_url: <% task(get_config).result.result.supr_api_url %>
+                irma_api_key: <% task(get_config).result.result.irma_api_key %>
+                delivery_service_url: <% task(get_config).result.result.delivery_service_url %>
+              on-success:
+                 - projects_on_runfolder
+
+            projects_on_runfolder:
+              action: core.http
+              input:
+                url: "<% $.delivery_service_url %>/api/1.0/runfolders/<% $.runfolder_name %>/projects"
+                method: "GET"
+              publish:
+                projects_on_runfolder: <% task(projects_on_runfolder).result.body.projects.name %>
+              on-success:
+                - get_pi_emails
+
+            get_pi_emails:
+              action: arteria-packs.read_projects_email_file
+              input:
+                file_path: <% $.projects_pi_email_file %>
+                projects:
+                  projects: <% $.projects_on_runfolder %>
+              publish:
+                projects_to_emails: <% task(get_pi_emails).result.result %>
+              on-success:
+                - get_pi_ids
+
+            get_pi_ids:
+              action: arteria-packs.get_pi_id_for_email_from_supr
+              input:
+                project_to_email_dict: <% $.projects_to_emails %>
+                api_user: <% $.supr_api_user %>
+                api_key: <% $.supr_api_key %>
+                supr_base_api_url: <% $.supr_api_url %>
+              publish:
+                pi_supr_ids: <% task(get_pi_ids).result.result %>
+              on-success:
+                - stage_runfolder
+
+            # TODO Figure out how to connect staging order to projects so that the correct
+            # staging can be corrected to the correct delivery downstream...
+            stage_runfolder:
+              action: arteria-packs.delivery_service_stage_runfolder
+              input:
+                 delivery_base_api_url: <% $.delivery_service_url %>
+                 runfolder_name: <% $.runfolder_name %>
+                 projects:
+                  projects: <% $.projects_on_runfolder %>
+              on-success:
+                - create_delivery_projects
+
+            create_delivery_projects:
+              with-items: project_name in <% $.pi_supr_ids.keys() %>
+              action: arteria-packs.create_delivery_project_in_super
+              input:
+                pi_id: <% $.pi_supr_ids.get($.project_name) %>
+                project_name: <% $.project_name %>
+                api_user: <% $.supr_api_user %>
+                api_key: <% $.supr_api_key %>
+

--- a/actions/workflows/delivery_runfolder_workflow.yaml
+++ b/actions/workflows/delivery_runfolder_workflow.yaml
@@ -80,7 +80,9 @@ workflows:
                  delivery_base_api_url: <% $.delivery_service_url %>
                  runfolder_name: <% $.runfolder_name %>
                  projects:
-                  projects: <% $.projects_on_runfolder %>
+                   projects: <% $.projects_on_runfolder %>
+                 publish:
+                   projects_and_stage_ids: <% task(stage_runfolder).result.result %>
               on-success:
                 - create_delivery_projects
 
@@ -92,4 +94,8 @@ workflows:
                 project_name: <% $.project_name %>
                 api_user: <% $.supr_api_user %>
                 api_key: <% $.supr_api_key %>
+              publish:
+                delivery_projects:
+                  <% $.project_name %>: <% task(create_delivery_projects).result.name %>
 
+            # TODO Remember to pass correct md5sum files for the project.

--- a/actions/workflows/delivery_runfolder_workflow.yaml
+++ b/actions/workflows/delivery_runfolder_workflow.yaml
@@ -34,7 +34,6 @@ workflows:
                 supr_api_user: <% task(get_config).result.result.supr_api_user %>
                 supr_api_key: <% task(get_config).result.result.supr_api_key %>
                 supr_api_url: <% task(get_config).result.result.supr_api_url %>
-                supr_api_url: <% task(get_config).result.result.supr_api_url %>
                 irma_api_key: <% task(get_config).result.result.irma_api_key %>
                 delivery_service_url: <% task(get_config).result.result.delivery_service_url %>
               on-success:

--- a/actions/workflows/delivery_runfolder_workflow.yaml
+++ b/actions/workflows/delivery_runfolder_workflow.yaml
@@ -81,21 +81,27 @@ workflows:
                  runfolder_name: <% $.runfolder_name %>
                  projects:
                    projects: <% $.projects_on_runfolder %>
-                 publish:
-                   projects_and_stage_ids: <% task(stage_runfolder).result.result %>
+              publish:
+                 projects_and_stage_ids: <% task(stage_runfolder).result.result %>
               on-success:
                 - create_delivery_projects
 
             create_delivery_projects:
-              with-items: project_name in <% $.pi_supr_ids.keys() %>
               action: arteria-packs.create_delivery_project_in_super
               input:
-                pi_id: <% $.pi_supr_ids.get($.project_name) %>
-                project_name: <% $.project_name %>
+                project_names_and_ids: <% $.pi_supr_ids %>
                 api_user: <% $.supr_api_user %>
                 api_key: <% $.supr_api_key %>
               publish:
-                delivery_projects:
-                  <% $.project_name %>: <% task(create_delivery_projects).result.name %>
+                delivery_projects: <% task(create_delivery_projects).result.result %>
+              on-success:
+                - deliver_runfolder
 
             # TODO Remember to pass correct md5sum files for the project.
+            deliver_runfolder:
+              action: arteria-packs.delivery_service_deliver
+              with-items: ngi_project_name in <% $.projects_and_stage_ids.keys() %>
+              input:
+                staging_id: <% $.projects_and_stage_ids.get($.ngi_project_name)%>
+                delivery_base_api_url: <% $.delivery_service_url %>
+                delivery_project_id: <% $.delivery_projects.get($.ngi_project_name).name %>

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,8 @@ irma_reports_remote_path: ./staging/reports/
 irma_checksum_base_url: https://irma1.uppmax.uu.se:4444/arteria_checksum_staging/api/1.0
 irma_siswrap_base_url: https://irma1.uppmax.uu.se:4444/arteria_siswrap_staging/api/1.0
 
+delivery_service_url: http://some-host.com:9999/
+
 irma_replace_expressions:
  - 's/UPPNEX_PROJECT: a2009002/UPPNEX_PROJECT: ngi2016001/'
  - 's/UPPNEX_QOS: seqver/#UPPNEX_QOS: seqver/'
@@ -45,3 +47,7 @@ charon_status_report_slack_channel: "#bottest"
 
 # String of file paths to exclude from the compressed archive (egrep syntax)
 archive_excludes: "\"'^./Config|^./InterOp|^./SampleSheet.csv|^./Unaligned|^./Data|^./Thumbnail_Images'\""
+supr_api_user: apiuser
+supr_api_key: apikey
+supr_api_url: https://disposer.c3se.chalmers.se/supr-test/api
+


### PR DESCRIPTION
This implements the delivery workflow for a runfolder for the following stages so far:

 - [x] Check which projects are available for runfolder
 - [x] Get emails for PIs for these projects
 - [x] Get PI id for PIs in SUPr
 - [x] Stage projects
 - [x] Create delivery projects for PIs
 - [x] Run and monitor delivery with mover

It should be ready for some initial code review at this point, but it's not yet ready to be merged.

In addition to this we will need to implement running deliveries on arbitrary folder structures - so that e.g. WGS projects can also be delivered.