### PR TITLE
Bug fix: calculate checksums for all files before archiving 

### DIFF
--- a/actions/workflows/archive_workflow.yaml
+++ b/actions/workflows/archive_workflow.yaml
@@ -53,7 +53,7 @@ workflows:
             generate_checksums:
                 action: core.local
                 input:
-                  cmd: ssh <% $.host %> "cd <% $.runfolder %> && find . -type f ! -path './Data/*' -and ! -path './Thumbnail_Images/*' -and ! -path './checksums_prior_to_pdc.md5' -exec md5sum {} + > checksums_prior_to_pdc.md5"
+                  cmd: ssh <% $.host %> "cd <% $.runfolder %> && find -L . -type f ! -path './Data/*' -and ! -path './Thumbnail_Images/*' -and ! -path './checksums_prior_to_pdc.md5' -exec md5sum {} + > checksums_prior_to_pdc.md5"
                 timeout: 86400 # 24 h timeout
                 on-success:
                   - tsm_archive_to_pdc


### PR DESCRIPTION
The find subprocess didn't follow symlinks correctly before. This made us miss calculating checksums for data under `Unaligned`, which usually are a symlink (on some of the test data sets `Unaligned` was setup as a standard folder). 