### PR TITLE
Timeout param was not set correctly

### DIFF
--- a/actions/workflows/archive_workflow.yaml
+++ b/actions/workflows/archive_workflow.yaml
@@ -52,7 +52,7 @@ workflows:
                 action: core.local
                 input:
                   cmd: ssh <% $.host %> "cd <% $.runfolder %> && find -L . -type f ! -path './Data/*' -and ! -path './Thumbnail_Images/*' -and ! -path './checksums_prior_to_pdc.md5' -exec md5sum {} + > checksums_prior_to_pdc.md5"
-                timeout: 86400 # 24 h timeout
+                  timeout: 86400 # 24 h timeout
                 on-success:
                   - tsm_archive_to_pdc
 


### PR DESCRIPTION
Due to indentation errors on the checksum action the default timeout 60 seconds was used instead. Due to mainly testing with MiSeq runfolders this default value was never hit during initial development, but of course when starting to calculate checksums for HiSeqX runfolders a longer period is required. This has been hot-fixed on arteria-master so that Matilda can run her archiving workflows manually. 