### PR TITLE
Deliver arbitrary project

### DIFF
--- a/actions/delivery_project_workflow.yaml
+++ b/actions/delivery_project_workflow.yaml
@@ -1,0 +1,25 @@
+---
+name: delivery_project_workflow
+description: Deliver a project (i.e. a directory placed in the directory defined by the arteria delivery service `general_project_directory` configuration)
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/delivery_project_workflow.yaml
+pack: arteria-packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: arteria-packs.delivery_project_workflow
+    immutable: true
+    type: string
+  project_name:
+    required: true
+    type: string
+    description: Name of the project (and the directory) to deliver
+  projects_pi_email_file:
+    required: true
+    type: string
+    description: file containing pi emails and projects
+

--- a/actions/delivery_service_stage_project.yaml
+++ b/actions/delivery_service_stage_project.yaml
@@ -1,5 +1,5 @@
 ---
-name: delivery_service_stage_runfolder
+name: delivery_service_stage_project
 runner_type: run-python
 description: Stage a runfolder through the Arteria delivery service
 enabled: true
@@ -10,15 +10,11 @@ parameters:
     action:
         type: string
         required: true
-        default: stage_runfolder
+        default: stage_project
         immutable: true
-    runfolder_name:
+    project_name:
         type: string
-        description: Name of the runfolder to stage
-        required: true
-    projects:
-        type: object
-        description: projects to stage as a json object looking like this {"projects":["ABC_123"]}
+        description: Name of the project to stage
         required: true
     delivery_base_api_url:
         type: string

--- a/actions/workflows/delivery_project_workflow.yaml
+++ b/actions/workflows/delivery_project_workflow.yaml
@@ -1,0 +1,84 @@
+version: "2.0" # mistral version
+name: arteria-packs.delivery_project_workflow
+description: Deliver data from a project (i.e. a directory with the project name) to a SNIC delivery project
+
+workflows:
+    main:
+        type: direct
+        input:
+          - project_name
+          - projects_pi_email_file
+
+        tasks:
+            note_workflow_version:
+              action: core.local
+              input:
+                cmd: git rev-parse HEAD
+                cwd: /opt/stackstorm/packs/arteria-packs/
+              on-success:
+                  - get_config
+
+            get_config:
+              action: arteria-packs.get_pack_config
+              publish:
+                supr_api_user: <% task(get_config).result.result.supr_api_user %>
+                supr_api_key: <% task(get_config).result.result.supr_api_key %>
+                supr_api_url: <% task(get_config).result.result.supr_api_url %>
+                irma_api_key: <% task(get_config).result.result.irma_api_key %>
+                delivery_service_url: <% task(get_config).result.result.delivery_service_url %>
+              on-success:
+                 - get_pi_emails
+
+            get_pi_emails:
+              action: arteria-packs.read_projects_email_file
+              input:
+                file_path: <% $.projects_pi_email_file %>
+                projects:
+                  projects:
+                   -  <% $.project_name %>
+              publish:
+                projects_to_emails: <% task(get_pi_emails).result.result %>
+              on-success:
+                - get_pi_ids
+
+            get_pi_ids:
+              action: arteria-packs.get_pi_id_for_email_from_supr
+              input:
+                project_to_email_dict: <% $.projects_to_emails %>
+                api_user: <% $.supr_api_user %>
+                api_key: <% $.supr_api_key %>
+                supr_base_api_url: <% $.supr_api_url %>
+              publish:
+                pi_supr_ids: <% task(get_pi_ids).result.result %>
+              on-success:
+                - stage_project
+
+            stage_project:
+              action: arteria-packs.delivery_service_stage_project
+              input:
+                 delivery_base_api_url: <% $.delivery_service_url %>
+                 project_name: <% $.project_name %>
+              publish:
+                 projects_and_stage_ids: <% task(stage_project).result.result %>
+              on-success:
+                - create_delivery_projects
+
+            create_delivery_projects:
+              action: arteria-packs.create_delivery_project_in_super
+              input:
+                project_names_and_ids: <% $.pi_supr_ids %>
+                api_user: <% $.supr_api_user %>
+                api_key: <% $.supr_api_key %>
+              publish:
+                delivery_projects: <% task(create_delivery_projects).result.result %>
+              on-success:
+                - deliver_project
+
+            # TODO Remember to pass correct md5sum files for the project.
+            deliver_project:
+              action: arteria-packs.delivery_service_deliver
+              with-items: ngi_project_name in <% $.projects_and_stage_ids.keys() %>
+              input:
+                staging_id: <% $.projects_and_stage_ids.get($.ngi_project_name)%>
+                delivery_base_api_url: <% $.delivery_service_url %>
+                delivery_project_id: <% $.delivery_projects.get($.ngi_project_name).name %>

--- a/actions/workflows/delivery_runfolder_workflow.yaml
+++ b/actions/workflows/delivery_runfolder_workflow.yaml
@@ -72,8 +72,6 @@ workflows:
               on-success:
                 - stage_runfolder
 
-            # TODO Figure out how to connect staging order to projects so that the correct
-            # staging can be corrected to the correct delivery downstream...
             stage_runfolder:
               action: arteria-packs.delivery_service_stage_runfolder
               input:


### PR DESCRIPTION
Added a delivery workflow which can deliver an arbitrary project (defined as a directory with the same name as the project placed in the location monitored by the arteria delivery service).

There is a fair amount of code duplication between this and the runfolder delivery workflow, but right now I'm not sure that refactoring this into subworkflows is worth the trouble. Especially since I guess we are dropping doing deliveries straight from runfolders in the future.