### PR TITLE
Archive a linked tree structure instead of filtering on TSM level 

### DIFF
--- a/actions/archive_workflow.yaml
+++ b/actions/archive_workflow.yaml
@@ -23,3 +23,8 @@ parameters:
     description: 'Path to runfolder to archive'
     required: true
     type: string
+  remove_previous_archive: 
+    description: 'Set to true to remove previous archive'
+    required: true
+    type: boolean
+    default: false

--- a/actions/compress_archive_package.yaml
+++ b/actions/compress_archive_package.yaml
@@ -1,5 +1,5 @@
 ---
-    name: 'prepare_archive_package'
+    name: 'compress_archive_package'
     runner_type: 'run-local'
     description: 'Creates a compressed archive of a subset of files inside a runfolder, ready to be sent to PDC with TSM.'
     enabled: true
@@ -26,7 +26,7 @@
             position: 3
         cmd:
             immutable: true 
-            default: 'ssh -v {{host}} "bash -s" < /opt/stackstorm/packs/arteria-packs/actions/lib/prepare_archive_package.sh {{ runfolder }} {{ exclude }}'
+            default: 'ssh -v {{host}} "bash -s" < /opt/stackstorm/packs/arteria-packs/actions/lib/compress_archive_package.sh {{ runfolder }} {{ exclude }}'
         connect_timeout:
             type: 'integer'
             description: 'SSH connect timeout in seconds'

--- a/actions/create_archive_dir.yaml
+++ b/actions/create_archive_dir.yaml
@@ -26,7 +26,7 @@
             required: true
         python_path:
             type: 'string'
-            description: 'Path to the Python 2.7 binary to use (hard coded for now)'
+            description: 'Path to the Python 2.7 binary to use'
             required: true
             default: '/opt/arteria/arteria-runfolder-env/bin/python'
         exclude_links: 

--- a/actions/create_archive_dir.yaml
+++ b/actions/create_archive_dir.yaml
@@ -1,0 +1,31 @@
+---
+    name: 'create_archive_dir'
+    runner_type: 'run-local'
+    description: 'Creates a copy of the runfolder, consisting of symlinks, for archiving purposes.'
+    enabled: true
+    entry_point: ''
+    parameters:
+        timeout:
+            default: 86400
+        runfolder:
+            type: 'string'
+            description: 'Path to runfolder to archive'
+            required: true
+            position: 1
+        fastq_threshold:
+            type: 'integer'
+            description: 'Action will fail if less than this number of fastq files are found'
+            required: true
+            position: 2
+        host:
+            type: 'string'
+            description: 'Host where runfolder is located'
+            required: true
+            position: 3
+        cmd:
+            immutable: true 
+            default: 'ssh -v {{host}} "bash -s" < /opt/stackstorm/packs/arteria-packs/actions/lib/create_archive_dir.py -e Data -e Thumbnail_Images -t {{ fastq_threshold }} {{ runfolder }}'
+        connect_timeout:
+            type: 'integer'
+            description: 'SSH connect timeout in seconds'
+            default: 86400 # 24 h

--- a/actions/create_archive_dir.yaml
+++ b/actions/create_archive_dir.yaml
@@ -22,9 +22,21 @@
             description: 'Host where runfolder is located'
             required: true
             position: 3
+        python_path:
+            type: 'string'
+            description: 'Path to the Python 2.7 binary to use (hard coded for now)'
+            required: true
+            position: 4
+            default: '/opt/arteria/arteria-runfolder-env/bin/python'
+        exclude_links: 
+            type: 'string'
+            description: 'Argument to script for which links we should not create'
+            required: false
+            position: 5
+            default: '-e Data -e Thumbnail_Images'
         cmd:
             immutable: true 
-            default: 'ssh -v {{host}} "bash -s" < /opt/stackstorm/packs/arteria-packs/actions/lib/create_archive_dir.py -e Data -e Thumbnail_Images -t {{ fastq_threshold }} {{ runfolder }}'
+            default: 'ssh -v {{ host }} "{{ python_path }} -u - {{ exclude_links }} -t {{ fastq_threshold }} {{ runfolder }}" < /opt/stackstorm/packs/arteria-packs/actions/lib/create_archive_dir.py'
         connect_timeout:
             type: 'integer'
             description: 'SSH connect timeout in seconds'

--- a/actions/create_archive_dir.yaml
+++ b/actions/create_archive_dir.yaml
@@ -11,32 +11,32 @@
             type: 'string'
             description: 'Path to runfolder to archive'
             required: true
-            position: 1
         fastq_threshold:
             type: 'integer'
             description: 'Action will fail if less than this number of fastq files are found'
             required: true
-            position: 2
+        remove_previous: 
+            type: 'boolean'
+            description: 'Set to true if we want to remove an already existing archive directory'
+            required: true
+            default: false
         host:
             type: 'string'
             description: 'Host where runfolder is located'
             required: true
-            position: 3
         python_path:
             type: 'string'
             description: 'Path to the Python 2.7 binary to use (hard coded for now)'
             required: true
-            position: 4
             default: '/opt/arteria/arteria-runfolder-env/bin/python'
         exclude_links: 
             type: 'string'
             description: 'Argument to script for which links we should not create'
             required: false
-            position: 5
             default: '-e Data -e Thumbnail_Images'
         cmd:
             immutable: true 
-            default: 'ssh -v {{ host }} "{{ python_path }} -u - {{ exclude_links }} -t {{ fastq_threshold }} {{ runfolder }}" < /opt/stackstorm/packs/arteria-packs/actions/lib/create_archive_dir.py'
+            default: 'ssh -v {{host}} "{{python_path}} -u - {{exclude_links}} -t {{fastq_threshold}} --remove={{remove_previous}} {{runfolder}}" < /opt/stackstorm/packs/arteria-packs/actions/lib/create_archive_dir.py'
         connect_timeout:
             type: 'integer'
             description: 'SSH connect timeout in seconds'

--- a/actions/lib/compress_archive_package.sh
+++ b/actions/lib/compress_archive_package.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Simple script that should be executed on a biotank when we want to prepare a
-# runfolder to be archived to PDC via TSM. 
+# Simple script that should be executed on a biotank when we want to compress a
+# runfolder to be archived to PDC via TSM. The runfolder to archive is expected
+# to be a folder full of symlinks pointing to real source folder. 
 
 set -e
 set -o pipefail 
@@ -13,14 +14,14 @@ RUNFOLDER_NAME=$(basename ${RUNFOLDER})
 
 # The exclude pattern is for everything we do not want to pack, and is configurable 
 # upstreams. It should hopefully look something like the following. 
-# EXCLUDE="^./Config|^./InterOp|^./SampleSheet.csv|^./Unaligned|^./runParameters.xml|^./RunInfo.xml"
+# EXCLUDE="^Config|^InterOp|^SampleSheet.csv|^Unaligned|^runParameters.xml|^RunInfo.xml"
 # Escaping various quotes can be messy though. 
 EXCLUDE=$2
 
 cd ${RUNFOLDER}
 
-# If the normal archive workflow is re-run then the tar ball shouldn't exist anymore. 
-# Still, just in case, abort if it is found. 
+# If the normal archive workflow is re-run then the tar ball shouldn't exist anymore because
+# the linked directory structory will be re-created from scratch. Still, just in case, abort if it is found. 
 if [ -f ./${RUNFOLDER_NAME}.tar.gz ]; then
   echo "Gziped archive file ${RUNFOLDER_NAME}.tar.gz already exists. Manual intervention required."
   exit 1

--- a/actions/lib/compress_archive_package.sh
+++ b/actions/lib/compress_archive_package.sh
@@ -21,7 +21,9 @@ EXCLUDE=$2
 cd ${RUNFOLDER}
 
 # If the normal archive workflow is re-run then the tar ball shouldn't exist anymore because
-# the linked directory structory will be re-created from scratch. Still, just in case, abort if it is found. 
+# either the linked directory structory will be re-created from scratch, or the workflow
+# should have aborted at an earlier stage because the archive dir already exists. 
+# Still, just in case, abort if it is found. 
 if [ -f ./${RUNFOLDER_NAME}.tar.gz ]; then
   echo "Gziped archive file ${RUNFOLDER_NAME}.tar.gz already exists. Manual intervention required."
   exit 1

--- a/actions/lib/create_archive_dir.py
+++ b/actions/lib/create_archive_dir.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+import os, sys, shutil, argparse
+
+def verify_src(srcdir, threshold = None):
+  if not os.path.exists(srcdir) or not os.path.isdir(srcdir):
+    print("Runfolder {} is not a directory and/or doesn't exist. Aborting.".format(srcdir))
+    sys.exit(1)
+
+  unaligned_link = os.path.join(os.path.sep, srcdir, "Unaligned")
+  unaligned_dir = os.path.abspath(unaligned_link)
+
+  if not os.path.exists(unaligned_link) or not os.path.islink(unaligned_link): 
+    print("Expected link {} doesn't seem to exist or is broken. Aborting.".format(unaligned_link))
+    sys.exit(1)
+  elif not os.path.exists(unaligned_dir) or not os.path.isdir(unaligned_dir): 
+    print("Expected directory {} doesn't seem to exist. Aborting.".format(unaligned_dir))
+    sys.exit(1) 
+  else:
+    counter = 0
+
+    for root, dirs, files in os.walk(unaligned_dir):
+      for file in files: 
+        if file.lower().endswith(".fastq.gz"):
+          print(os.path.join(root, file))
+          counter = counter + 1
+  
+    if threshold and counter < threshold: 
+        print("We only found {} files that seems to be FASTQ files. Expecting at least {} files. Looks suspicious; aborting.".format(counter, threshold))
+        sys.exit(1)
+
+def verify_dest(destdir): 
+  if os.path.exists(destdir):
+    print("Archive directory {} already exists. Will remove it first.".format(destdir))
+    shutil.rmtree(destdir)
+
+def create_dest(srcdir, destdir, exclude = None): 
+  os.makedirs(destdir)
+
+  for entry in os.listdir(srcdir):
+    if not entry in exclude: 
+      os.symlink(os.path.join(srcdir, entry), os.path.join(destdir, entry))
+ 
+  print("Archive directory {} created successfully.".format(destdir))
+
+if __name__ == "__main__": 
+  parser = argparse.ArgumentParser(description="Takes a runfolder's path as an argument and creates a copy of it with symlinks\n"\
+                                               "as its content, suitable for archiving to PDC. Created copy will be placed in\n"\
+                                               "the same root path as the runfolder, with suffix '_archive'. If the destination\n"\
+                                               "copy already exists then it will be overwritten.\n\n"\
+                                               "The script will also scan for expected subdir/link 'Unaligned' in the runfolder\n"\
+                                               "to archive. If it doesn't exist then it will abort. Inside 'Unaligned' it will\n"\
+                                               "look for fastq.gz files. If the number of files found are less than the\n"\
+                                               "specified threshold value then the script will abort.",
+                                   formatter_class=argparse.RawTextHelpFormatter)
+  parser.add_argument("runfolder", help="path to the runfolder to archive")
+  parser.add_argument("-e", "--exclude", action='append', help="filename to exclude from archive (argument can be repeated)")
+  parser.add_argument("-t", "--threshold", default=10, type=int, help="will abort if less than this many FASTQ files are found (default 10)") 
+  args = parser.parse_args()
+  srcdir = os.path.abspath(args.runfolder)
+  exclude = args.exclude
+  threshold = args.threshold
+
+  destdir = srcdir + "_archive" 
+  verify_src(srcdir, threshold)
+  verify_dest(destdir)
+  create_dest(srcdir, destdir, exclude)

--- a/actions/lib/create_archive_dir.py
+++ b/actions/lib/create_archive_dir.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="Takes a runfolder's path as an argument and creates a copy of it with symlinks\n"\
                                                "as its content, suitable for archiving to PDC. Created copy will be placed in\n"\
                                                "the same root path as the runfolder, with suffix '_archive'. If the destination\n"\
-                                               "copy already exists then it will be overwritten.\n\n"\
+                                               "copy already exists then the script will abort.\n\n"\
                                                "The script will also scan for expected subdir/link 'Unaligned' in the runfolder\n"\
                                                "to archive. If it doesn't exist then it will abort. Inside 'Unaligned' it will\n"\
                                                "look for fastq.gz files. If the number of files found are less than the\n"\

--- a/actions/lib/prepare_archive_package.sh
+++ b/actions/lib/prepare_archive_package.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # Simple script that should be executed on a biotank when we want to prepare a
-# runfolder to be archived to PDC via TSM.
+# runfolder to be archived to PDC via TSM. 
 
 set -e
+set -o pipefail 
 
 # The full path to the runfolder that we want to archive.
 RUNFOLDER=$1
@@ -12,35 +13,36 @@ RUNFOLDER_NAME=$(basename ${RUNFOLDER})
 
 # The exclude pattern is for everything we do not want to pack, and is configurable 
 # upstreams. It should hopefully look something like the following. 
-# EXCLUDE="^./Config|^./InterOp|^./SampleSheet.csv|^./Unaligned|^./Data|^./Thumbnail_Images|^./runParameters.xml|^./RunInfo.xml"
+# EXCLUDE="^./Config|^./InterOp|^./SampleSheet.csv|^./Unaligned|^./runParameters.xml|^./RunInfo.xml"
 # Escaping various quotes can be messy though. 
 EXCLUDE=$2
 
 cd ${RUNFOLDER}
 
-# TODO: Shall we upload it when it exists?
+# If the normal archive workflow is re-run then the tar ball shouldn't exist anymore. 
+# Still, just in case, abort if it is found. 
 if [ -f ./${RUNFOLDER_NAME}.tar.gz ]; then
   echo "Gziped archive file ${RUNFOLDER_NAME}.tar.gz already exists. Manual intervention required."
   exit 1
 fi
 
-# Create list of files to include in the compressed part of the archive.
-# Should have a couple of file patterns excluded from the config.
-# Note that we're only adding the files, and not the directories, because
-# it would cause tar to return with a failure code when removing directories
-# before files in subdirs have been removed. (And if we use the exclude features
-# from tar instead then it will always add "." which causes its own problems
-# as it can't be removed.)
-find . -type f -print | egrep -v ${EXCLUDE} > ./.files-to-pack
+# Create list of root links to include in the compressed part of the archive.
+# Should have a couple of file patterns excluded from the config. 
+# 
+# NB: As this works now the excluded files from the tar ball must be a link
+# in the root folder. If we want to be able to exclude files deeper in the 
+# directory tree then we need to redo this step, as well as the tar and 
+# removal step. 
+ls -A | egrep -v ${EXCLUDE} > ./.links-to-pack
 
-# Pack everything together and then remove them at the same time. More
-# efficiently space wise than removing them afterwards. Compressing is perhaps
-# not strictly necessary, but it will save some space for primarily the log files.
-tar -T ./.files-to-pack -c -z -f ./${RUNFOLDER_NAME}.tar.gz --remove-files
+# Pack everything together. Compressing is perhaps not strictly necessary, but it 
+# will save some space for primarily the log files. We want to derefence symlinks, 
+# as normal procedure is to archive a runfolder full with symlinks to the files 
+# that should be uploaded.
+tar -h -T ./.links-to-pack -c -z -f ./${RUNFOLDER_NAME}.tar.gz 
 
-# Optional step: remove all the empty dirs that will now exist due to the
-# removed files. When extracting the archive the dirs with files will be
-# created. Obviously any dirs without any files will be lost. Also note
-# that this will change the timestamp on these newly created dirs, but I'm
-# guessing that is OK.
-find . -type d -empty -delete
+# Remove all symlinks that we include in the tar ball 
+for link in `cat ${RUNFOLDER}/.links-to-pack`; do 
+    rm ${RUNFOLDER}/${link}
+done
+

--- a/actions/ngi_uu_workflow.yaml
+++ b/actions/ngi_uu_workflow.yaml
@@ -59,3 +59,11 @@ parameters:
     default: 1
     type: integer
     description: "Value of new read number"
+  skip_archiving: 
+    default: false
+    type: boolean
+    description: "Set to true to skip archive subworkflow"
+  remove_previous_archive_dir: 
+    default: false
+    type: boolean
+    description: "Set to true to remove previous archive dir; e.g. if re-running a workflow"

--- a/actions/workflows/archive_workflow.yaml
+++ b/actions/workflows/archive_workflow.yaml
@@ -19,12 +19,15 @@ workflows:
                 cmd: git rev-parse HEAD
                 cwd: /opt/stackstorm/packs/arteria-packs/
               on-success:
-                - get_excludes
+                - get_config
 
-            get_excludes:
+            get_config:
               action: arteria-packs.get_pack_config
               publish:
-                archive_excludes: <% task(get_excludes).result.result.archive_excludes %>
+                archive_excludes: <% task(get_config).result.result.archive_excludes %>
+                archive_fastq_threshold: <% task(get_config).result.result.archive_fastq_threshold %>
+                archive_python_path: <% task(get_config).result.result.archive_python_path %>
+                archive_exclude_links: <% task(get_config).result.result.archive_exclude_links %>
               on-success:
                 - create_archive_dir
 
@@ -36,13 +39,15 @@ workflows:
               input: 
                 host: <% $.host %>
                 runfolder: <% $.runfolder %>
-                fastq_threshold: 10 # number of fastq files to expect; if less then the action will fail
+                fastq_threshold: <% $.archive_fastq_threshold %> # number of fastq files to expect; if less then the action will fail
+                python_path: <% $.archive_python_path %>
+                exclude_links: <% $.archive_exclude_links %>
               on-success: 
-                - prepare_tsm_archive     
+                - compress_tsm_archive     
             
             # Will compress some of the files in the archive. Script will fail if gziped archive already exists. 
-            prepare_tsm_archive:
-               action: arteria-packs.prepare_archive_package
+            compress_tsm_archive:
+               action: arteria-packs.compress_archive_package
                input:
                  host: <% $.host %>
                  runfolder: <% $.runfolder %>_archive

--- a/actions/workflows/archive_workflow.yaml
+++ b/actions/workflows/archive_workflow.yaml
@@ -73,7 +73,4 @@ workflows:
                   cmd: ssh <% $.host %> "dsmc archive <% $.runfolder %>_archive/ -subdir=yes -description=`uuidgen`"
                   timeout: 604800 # 1w worst-case timeout
 
-            # TODO: Implement a separate workflow that for an interval does a random download (if enough disk space exists)
-            # that does a "md5sum -c checksums_prior_to_pdc.md5"
-
             ### TRANSFER FILES END ###

--- a/actions/workflows/archive_workflow.yaml
+++ b/actions/workflows/archive_workflow.yaml
@@ -26,32 +26,34 @@ workflows:
               publish:
                 archive_excludes: <% task(get_excludes).result.result.archive_excludes %>
               on-success:
-                - prepare_tsm_archive
+                - create_archive_dir
 
             ### GENERAL TASKS END ###
 
             ### TRANSFER FILES START ###
-            # Will remove all files not excluded, after they've been added to the tar archive
-            # TODO: Script will fail if gziped archive already exists. Manually extract it for now
-            # if the workflow should be re-run.
+            create_archive_dir: 
+              action: arteria-packs.create_archive_dir
+              input: 
+                host: <% $.host %>
+                runfolder: <% $.runfolder %>
+                fastq_threshold: 10 # number of fastq files to expect; if less then the action will fail
+              on-success: 
+                - prepare_tsm_archive     
+            
+            # Will compress some of the files in the archive. Script will fail if gziped archive already exists. 
             prepare_tsm_archive:
                action: arteria-packs.prepare_archive_package
                input:
                  host: <% $.host %>
-                 runfolder: <% $.runfolder %>
+                 runfolder: <% $.runfolder %>_archive
                  exclude: <% $.archive_excludes %>
                on-success:
                  - generate_checksums
 
-            # Don't generate checksums for Data and Thumbnail_Images, because those will be filtered out
-            # by TSM when uploading to PDC, but we do want to keep them locally for a while if we
-            # want to re-process the runfolder. Notes that it is only the files that gets filtered out,
-            # the empty subdirs will still be uploaded.
-            # TODO: How to best pass these checksum excludes from config? Hardcoded for now.
             generate_checksums:
                 action: core.local
                 input:
-                  cmd: ssh <% $.host %> "cd <% $.runfolder %> && find -L . -type f ! -path './Data/*' -and ! -path './Thumbnail_Images/*' -and ! -path './checksums_prior_to_pdc.md5' -exec md5sum {} + > checksums_prior_to_pdc.md5"
+                  cmd: ssh <% $.host %> "cd <% $.runfolder %>_archive && find -L . -type f ! -path './checksums_prior_to_pdc.md5' -exec md5sum {} + > checksums_prior_to_pdc.md5"
                   timeout: 86400 # 24 h timeout
                 on-success:
                   - tsm_archive_to_pdc
@@ -61,7 +63,7 @@ workflows:
             tsm_archive_to_pdc:
                 action: core.local
                 input:
-                  cmd: ssh <% $.host %> "dsmc archive <% $.runfolder %>/ -subdir=yes -description=`uuidgen` | egrep -v '<% $.runfolder %>/Data/|<% $.runfolder %>/Thumbnail_Images/'"
+                  cmd: ssh <% $.host %> "dsmc archive <% $.runfolder %>_archive/ -subdir=yes -description=`uuidgen`"
                   timeout: 604800 # 1w worst-case timeout
 
             # TODO: Implement a separate workflow that for an interval does a random download (if enough disk space exists)

--- a/actions/workflows/archive_workflow.yaml
+++ b/actions/workflows/archive_workflow.yaml
@@ -8,6 +8,7 @@ workflows:
         input:
             - runfolder
             - host
+            - remove_previous_archive
         output:
             output_the_whole_workflow_context: <% $ %>
 
@@ -42,6 +43,7 @@ workflows:
                 fastq_threshold: <% $.archive_fastq_threshold %> # number of fastq files to expect; if less then the action will fail
                 python_path: <% $.archive_python_path %>
                 exclude_links: <% $.archive_exclude_links %>
+                remove_previous: <% $.remove_previous_archive %>
               on-success: 
                 - compress_tsm_archive     
             

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -17,6 +17,8 @@ workflows:
             - conversionstats_swap_read_nr
             - conversionstats_swap_read_from
             - conversionstats_swap_read_to
+            - skip_archiving
+            - remove_previous_archive_dir  
         output:
             output_the_whole_workflow_context: <% $ %>
         task-defaults:
@@ -338,7 +340,9 @@ workflows:
                   verify_ssl_cert: False
                   irma_mode: True
                on-success:
-                - upload_runfolder_to_pdc
+                - upload_runfolder_to_pdc: <% $.skip_archiving = false %>
+                - notify_finished: <% $.skip_archiving = true %>
+                - mark_as_finished: <% $.skip_archiving = true %>
 
             ### END AEACUS REPORT STEPS ###
             # TODO Need to add starting the ngi pipeline on irma
@@ -367,7 +371,9 @@ workflows:
                     env:
                         PERL5LIB: /proj/a2009002/perl/lib/perl5/
                 on-success:
-                    - upload_runfolder_to_pdc
+                    - upload_runfolder_to_pdc: <% $.skip_archiving = false %>
+                    - notify_finished: <% $.skip_archiving = true %>
+                    - mark_as_finished: <% $.skip_archiving = true %>
             ## START AEACUS REPORT STEPS END ###
 
             ## START NGI_PIPELINE IF NECESSARY ##
@@ -384,6 +390,7 @@ workflows:
                 input:
                     runfolder: <% $.runfolder %>
                     host: <% $.host %>
+                    remove_previous_archive: <% $.remove_previous_archive_dir %>
                 on-success:
                   - notify_finished
                   - mark_as_finished

--- a/config.yaml
+++ b/config.yaml
@@ -46,7 +46,14 @@ slack_webhook_url: https://slack.webhook.url
 charon_status_report_slack_channel: "#bottest"
 
 # String of file paths to exclude from the compressed archive (egrep syntax)
-archive_excludes: "\"'^./Config|^./InterOp|^./SampleSheet.csv|^./Unaligned|^./runParameters.xml|^./RunInfo.xml\""
+archive_excludes: "\"'^Config|^InterOp|^SampleSheet.csv|^Unaligned|^runParameters.xml|^RunInfo.xml\""
+# Which file entries we should not link to when creating the archive copy of the runfolder 
+archive_exclude_links: "-e Data -e Thumbnail_Images"
+# Number of fastq files to expect when creating archive. If we find less files than this 
+# then the action will fail. 
+archive_fastq_threshold: 10
+archive_python_path: /opt/arteria/arteria-runfolder-env/bin/python
+
 supr_api_user: apiuser
 supr_api_key: apikey
 supr_api_url: https://disposer.c3se.chalmers.se/supr-test/api

--- a/config.yaml
+++ b/config.yaml
@@ -46,7 +46,7 @@ slack_webhook_url: https://slack.webhook.url
 charon_status_report_slack_channel: "#bottest"
 
 # String of file paths to exclude from the compressed archive (egrep syntax)
-archive_excludes: "\"'^./Config|^./InterOp|^./SampleSheet.csv|^./Unaligned|^./Data|^./Thumbnail_Images'\""
+archive_excludes: "\"'^./Config|^./InterOp|^./SampleSheet.csv|^./Unaligned|^./runParameters.xml|^./RunInfo.xml\""
 supr_api_user: apiuser
 supr_api_key: apikey
 supr_api_url: https://disposer.c3se.chalmers.se/supr-test/api


### PR DESCRIPTION
@MatildaAslin , @slohse: Feel free to give input to the below if you have time/interest, so you both can start having a bit better insight into how the workflows are built up. 

Instead of filtering on TSM level which files we should include and exclude in the upload to PDC we will now instead create a linked tree structure called `<runfolder>_archive` with the `create_archive_dir.py` script. This also gives us less output from the TSM client 

The previous script that compressed the archive is modified somewhat to work properly with the links. 

When launching the NGI UU workflow one can now set a param `skip_archiving=true` to skip the archive subworkflow (practical e.g. when testing other parts of the workflow in staging). An other option is also added if the operator wants to re-run an archiving step. Then one has to specify `remove_previous_archive_dir=true` to force the removal of the previous `<runfolder>_archive` directory. 

These things have been tested on staging with a MiSeq and a HiSeq runfolder in various degrees. 