### PR TITLE
Log version of Arteria service and bcl2fastq used

### DIFF
--- a/actions/poll_status.py
+++ b/actions/poll_status.py
@@ -11,9 +11,6 @@ from requests.exceptions import RequestException
 # Needs to be run in a Stackstorm virtualenv
 from st2actions.runners.pythonrunner import Action
 
-
-
-
 class PollStatus(Action):
     """
     Polls a give micro service URL for current status of some long running process.
@@ -50,6 +47,7 @@ class PollStatus(Action):
         try:
             response = requests.post(endpoint, json=body, verify=verify_ssl_cert)
             response_json = response.json()
+            self.logger.info("Service accepted our request and responded with payload: {}".format(response_json))
 
             if irma_mode:
                 modified_link = _rewrite_link(response_json['link'])

--- a/actions/poll_status.py
+++ b/actions/poll_status.py
@@ -47,14 +47,13 @@ class PollStatus(Action):
         try:
             response = requests.post(endpoint, json=body, verify=verify_ssl_cert)
             response_json = response.json()
-            self.logger.info("Service accepted our request and responded with payload: {}".format(response_json))
 
             if irma_mode:
                 modified_link = _rewrite_link(response_json['link'])
                 self.logger.info("In irma mode, will rewrite link to: {}".format(modified_link))
-                return modified_link
+                return {"response": response_json, "url": modified_link}
             else:
-                return response_json['link']
+                return {"response": response_json, "url": response_json['link']}
         except RequestException as err:
             self.logger.error("An error was encountered when trying to "
                                 "post to url: {0}, {1}".format(endpoint, err))
@@ -126,7 +125,9 @@ class PollStatus(Action):
                 return False, json_resp
 
     def run(self, url, body, sleep, ignore_result, irma_mode, verify_ssl_cert, max_retries=3):
-        status_link = self.post_to_endpoint(url, body, irma_mode, verify_ssl_cert)
-        return self.check_status(status_link, sleep, ignore_result, verify_ssl_cert, max_retries)
+        start_response = self.post_to_endpoint(url, body, irma_mode, verify_ssl_cert) 
+        status_link = start_response['url']
+        status_val, status_response = self.check_status(status_link, sleep, ignore_result, verify_ssl_cert, max_retries)
+        return status_val, { "response_from_start": start_response, "response_from_last_status_check": status_response }
 
 

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -125,6 +125,18 @@ workflows:
                     url: "http://<% $.host %>:<% $.bcl2fastq_service_port %>/api/1.0/start/<% $.runfolder_name %>"
                     timeout: 86400 # Wait for 24 h before timing out.
                     body: <% $.bcl2fastq_body %>
+                on-success: 
+                    - save_bcl2fastq_version
+
+            # Save the bcl2fastq version that we used in a file inside the runfolder. 
+            # The version is included in stderr from the previous action as JSON bundled
+            # inside a long text string. So first we parse out the dict from the first line
+            # of stderr, and then we fetch the field to be saved on disk. Note that we need
+            # to launch the oneliner in a subshell for the pipefail to be set properly.  
+            save_bcl2fastq_version: 
+                action: core.local
+                input:
+                    cmd: bash -c "set -o pipefail && echo -e \"<% task(run_bcl2fastq).result.stderr %>\" | cut -d '{' -f2 | cut -d'}' -f1 | python -c \"import ast,sys; print ast.literal_eval('{' + sys.stdin.readline() + '}')['bcl2fastq_version']\" | ssh <% $.host %> \"cat - > <% $.runfolder %>/bcl2fastq_version\""
                 on-success:
                     - conversionstats_workaround: <% $.conversionstats_swap_read_nr = true %>
                     - download_sisyphus_config: <% $.conversionstats_swap_read_nr = false %>

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -128,15 +128,10 @@ workflows:
                 on-success: 
                     - save_bcl2fastq_version
 
-            # Save the bcl2fastq version that we used in a file inside the runfolder. 
-            # The version is included in stderr from the previous action as JSON bundled
-            # inside a long text string. So first we parse out the dict from the first line
-            # of stderr, and then we fetch the field to be saved on disk. Note that we need
-            # to launch the oneliner in a subshell for the pipefail to be set properly.  
             save_bcl2fastq_version: 
                 action: core.local
                 input:
-                    cmd: bash -c "set -o pipefail && echo -e \"<% task(run_bcl2fastq).result.stderr %>\" | cut -d '{' -f2 | cut -d'}' -f1 | python -c \"import ast,sys; print ast.literal_eval('{' + sys.stdin.readline() + '}')['bcl2fastq_version']\" | ssh <% $.host %> \"cat - > <% $.runfolder %>/bcl2fastq_version\""
+                    cmd: ssh <% $.host %> "echo <% task(run_bcl2fastq).result.result.response_from_start.response.bcl2fastq_version %> > <% $.runfolder %>/bcl2fastq_version"
                 on-success:
                     - conversionstats_workaround: <% $.conversionstats_swap_read_nr = true %>
                     - download_sisyphus_config: <% $.conversionstats_swap_read_nr = false %>


### PR DESCRIPTION
Changes `poll_status.py` so that the microservice's response payload is written out (will appear in Stackstorms stderr field for the action). That way we e.g. can see what version of Sisyphus that was used for the arteria-siswrap actions. 

Also adds a new action to the NGI UU workflow that parses the stderr from the bcl2fastq action, looking for the payload in the first line of the stderr string. It will then save the bcl2fastq version used into the file `<runfolder>/bcl2fastq_version`. 

Tested on a MiSeq runfolder in staging. 