### PR TITLE
Pass size of delivery along when creating delivery project

### DIFF
--- a/actions/create_delivery_project_in_supr.yaml
+++ b/actions/create_delivery_project_in_supr.yaml
@@ -16,6 +16,10 @@ parameters:
         type: object
         required: true
         description: Dictionary of project names to pi ids.
+    project_info:
+        type: object
+        required: true
+        description: Dictionary with project information, e.g. the size of the allocation of the project
     supr_base_api_url:
         type: string
         description: Email adress to look for associated PI for.

--- a/actions/supr.py
+++ b/actions/supr.py
@@ -46,7 +46,7 @@ class Supr(Action):
         return res
 
     @staticmethod
-    def create_delivery_project(base_url, project_names_and_ids, user, key):
+    def create_delivery_project(base_url, project_names_and_ids, project_info, user, key):
 
         result = {}
         for ngi_project_name, pi_id in project_names_and_ids.iteritems():
@@ -58,6 +58,9 @@ class Supr(Action):
             six_months_from_now = today + relativedelta(months=+6)
             six_months_from_now_formatted = six_months_from_now.strftime(Supr.DATE_FORMAT)
 
+            # Check smallest of delivery size in bytes and one gb (api wants size passed in giga bytes)
+            size_of_delivery = max(1, project_info[ngi_project_name]['size']/pow(10, 9))
+
             payload = {
                 'ngi_project_name': ngi_project_name,
                 'title': "DELIVERY_{}_{}".format(ngi_project_name, today_formatted),
@@ -65,9 +68,7 @@ class Supr(Action):
                 'start_date': today_formatted,
                 'end_date': six_months_from_now_formatted,
                 'continuation_name': '',
-                # TODO Right now this default to 1T, we might want to get something
-                # realistic in here later.
-                # 'allocated': size_of_delivery,
+                'allocated': size_of_delivery,
                 'api_opaque_data': '',
                 'ngi_ready': False,
                 'ngi_delivery_status': ''
@@ -89,7 +90,10 @@ class Supr(Action):
         if action == "get_id_from_email":
             return self.search_for_pis(kwargs['project_to_email_dict'], supr_base_api_url, api_user, api_key)
         elif action == 'create_delivery_project':
-            return self.create_delivery_project(supr_base_api_url, kwargs['project_names_and_ids'], api_user, api_key)
+            return self.create_delivery_project(supr_base_api_url,
+                                                kwargs['project_names_and_ids'],
+                                                kwargs['project_info'],
+                                                api_user, api_key)
         else:
             raise AssertionError("Action: {} was not recognized.".format(action))
 

--- a/actions/supr.py
+++ b/actions/supr.py
@@ -2,6 +2,7 @@
 
 import requests
 import json
+import math
 from datetime import date
 from dateutil.relativedelta import relativedelta
 
@@ -59,7 +60,7 @@ class Supr(Action):
             six_months_from_now_formatted = six_months_from_now.strftime(Supr.DATE_FORMAT)
 
             # Check smallest of delivery size in bytes and one gb (api wants size passed in giga bytes)
-            size_of_delivery = max(1, project_info[ngi_project_name]['size']/pow(10, 9))
+            size_of_delivery = max(1, math.ceil(project_info[ngi_project_name]['size']/pow(10, 9)))
 
             payload = {
                 'ngi_project_name': ngi_project_name,

--- a/actions/workflows/delivery_project_workflow.yaml
+++ b/actions/workflows/delivery_project_workflow.yaml
@@ -67,6 +67,7 @@ workflows:
               action: arteria-packs.create_delivery_project_in_super
               input:
                 project_names_and_ids: <% $.pi_supr_ids %>
+                project_info: <% $.projects_and_stage_ids %>
                 api_user: <% $.supr_api_user %>
                 api_key: <% $.supr_api_key %>
               publish:
@@ -79,6 +80,6 @@ workflows:
               action: arteria-packs.delivery_service_deliver
               with-items: ngi_project_name in <% $.projects_and_stage_ids.keys() %>
               input:
-                staging_id: <% $.projects_and_stage_ids.get($.ngi_project_name)%>
+                staging_id: <% $.projects_and_stage_ids.get($.ngi_project_name).staging_id %>
                 delivery_base_api_url: <% $.delivery_service_url %>
                 delivery_project_id: <% $.delivery_projects.get($.ngi_project_name).name %>

--- a/actions/workflows/delivery_runfolder_workflow.yaml
+++ b/actions/workflows/delivery_runfolder_workflow.yaml
@@ -88,6 +88,7 @@ workflows:
               action: arteria-packs.create_delivery_project_in_super
               input:
                 project_names_and_ids: <% $.pi_supr_ids %>
+                project_info: <% $.projects_and_stage_ids %>
                 api_user: <% $.supr_api_user %>
                 api_key: <% $.supr_api_key %>
               publish:
@@ -100,6 +101,6 @@ workflows:
               action: arteria-packs.delivery_service_deliver
               with-items: ngi_project_name in <% $.projects_and_stage_ids.keys() %>
               input:
-                staging_id: <% $.projects_and_stage_ids.get($.ngi_project_name)%>
+                staging_id: <% $.projects_and_stage_ids.get($.ngi_project_name).staging_id %>
                 delivery_base_api_url: <% $.delivery_service_url %>
                 delivery_project_id: <% $.delivery_projects.get($.ngi_project_name).name %>


### PR DESCRIPTION
This code ensures that we pick up the size of a delivery and pass it along when creating a delivery project. The smallest allocation it will make in supr is for 1 GB, otherwise it will be the size of the delivery in GB rounding up.