### PR TITLE
Changes preping to use the real mover

### DIFF
--- a/actions/arteria_delivery_service.py
+++ b/actions/arteria_delivery_service.py
@@ -26,8 +26,10 @@ class ArteriaQuerierBase(object):
 
         def update_links(links_results):
             for link, state in links_results.iteritems():
-                if state == self.successful_status() or state in self.failed_status():
+                if state == self.successful_status():
                     continue
+                elif state in self.failed_status():
+                    raise Exception("Gor a failed status from link: {}".format(link))
                 elif state in self.valid_status() or not state:
                     response = requests.get(link)
                     response_as_json = json.loads(response.content)
@@ -77,7 +79,6 @@ class ArteriaStagingQuerier(ArteriaQuerierBase):
         valid_states = [self.staging_successful, self.staging_failed, self.staging_pending, self.staging_in_progress]
         return valid_states
 
-
 class ArteriaDeliveryQuerier(ArteriaQuerierBase):
 
     pending = 'pending'
@@ -86,21 +87,48 @@ class ArteriaDeliveryQuerier(ArteriaQuerierBase):
     delivery_in_progress = 'delivery_in_progress'
     delivery_successful = 'delivery_successful'
     delivery_failed = 'delivery_failed'
+    delivery_skipped = 'delivery_skipped'
+
+    valid_states = [pending, mover_processing_delivery, mover_failed_delivery,
+                    delivery_in_progress, delivery_successful, delivery_failed]
+
+    successful_states = delivery_successful
 
     def __init__(self, logger):
         super(ArteriaDeliveryQuerier, self).__init__(logger)
 
     def successful_status(self):
-        return self.delivery_successful
+        return self.successful_states
 
     def failed_status(self):
         return [self.mover_failed_delivery, self.delivery_failed]
 
     def valid_status(self):
-        valid_states = [self.pending, self.mover_processing_delivery, self.mover_failed_delivery,
-                        self.delivery_in_progress, self.delivery_successful, self.delivery_failed]
-        return valid_states
+        return self.valid_states
 
+    def query_for_status(self, link, skip_mover):
+        if skip_mover:
+            self.valid_states += self.delivery_skipped
+            self.successful_states = self.delivery_skipped
+
+        while True:
+            response = requests.get(link)
+            response_as_json = json.loads(response.content)
+            status = response_as_json["status"]
+
+            if status == self.successful_status():
+                self.logger.info("Got successful status {}".format(status))
+                return True
+            elif status in self.failed_status():
+                self.logger.warning("Got unsuccessful status {}".format(status))
+                return False
+            elif status in self.valid_status():
+                self.logger.info("Got valid, but not final status, status: {}. Will keep polling.".format(status))
+                # TODO Make timeout configurable
+                time.sleep(5)
+            else:
+                self.logger.error("Got unrecognized status: {}. Will abort polling.".format(status))
+                return False
 
 class ArteriaDeliveryService(Action):
 
@@ -124,16 +152,21 @@ class ArteriaDeliveryService(Action):
         response = self.post_to_server(url, payload)
         return response
 
-    def deliver(self, base_url, staging_id, delivery_project_id, md5sum_file):
+    def deliver(self, base_url, staging_id, delivery_project_id, md5sum_file, skip_mover):
         url = '{}/{}/{}'.format(base_url, 'api/1.0/deliver/stage_id', str(staging_id))
         payload = {'delivery_project_id': delivery_project_id}
 
         if md5sum_file:
             payload['md5sum_file'] = md5sum_file
 
+        self.logger.debug("skip_mover was set to: {}".format(skip_mover))
+
+        if skip_mover:
+            payload['skip_mover'] = True
+
         response = self.post_to_server(url, payload)
-        links = response['delivery_order_link']
-        return [links]
+        link = response['delivery_order_link']
+        return link
 
     def stage_and_check_status(self, url, projects):
         response = self.stage_delivery(url,
@@ -182,12 +215,16 @@ class ArteriaDeliveryService(Action):
                                                           kwargs["project_name"])
 
         elif action == "deliver":
-            status_links = self.deliver(delivery_base_api_url,
+            status_link = self.deliver(delivery_base_api_url,
                                         kwargs['staging_id'],
                                         kwargs['delivery_project_id'],
-                                        kwargs.get('md5sum_file'))
+                                        kwargs.get('md5sum_file'),
+                                        kwargs.get('skip_mover'))
+            return True, {"project_name": kwargs["ngi_project_name"], "status_link": status_link}
+        elif action == "delivery_status":
+            status_endpoint = kwargs['status_link']
             arteria_delivery_querier = ArteriaDeliveryQuerier(self.logger)
-            return arteria_delivery_querier.query_for_status(status_links)
+            return arteria_delivery_querier.query_for_status(status_endpoint, kwargs.get('skip_mover'))
         else:
             raise AssertionError("Action: {} was not recognized.".format(action))
 

--- a/actions/arteria_delivery_service.py
+++ b/actions/arteria_delivery_service.py
@@ -92,13 +92,13 @@ class ArteriaDeliveryQuerier(ArteriaQuerierBase):
     valid_states = [pending, mover_processing_delivery, mover_failed_delivery,
                     delivery_in_progress, delivery_successful, delivery_failed]
 
-    successful_states = delivery_successful
+    successful_state = delivery_successful
 
     def __init__(self, logger):
         super(ArteriaDeliveryQuerier, self).__init__(logger)
 
     def successful_status(self):
-        return self.successful_states
+        return self.successful_state
 
     def failed_status(self):
         return [self.mover_failed_delivery, self.delivery_failed]
@@ -109,7 +109,7 @@ class ArteriaDeliveryQuerier(ArteriaQuerierBase):
     def query_for_status(self, link, skip_mover):
         if skip_mover:
             self.valid_states += self.delivery_skipped
-            self.successful_states = self.delivery_skipped
+            self.successful_state = self.delivery_skipped
 
         while True:
             response = requests.get(link)
@@ -129,6 +129,7 @@ class ArteriaDeliveryQuerier(ArteriaQuerierBase):
             else:
                 self.logger.error("Got unrecognized status: {}. Will abort polling.".format(status))
                 return False
+
 
 class ArteriaDeliveryService(Action):
 

--- a/actions/delivery_project_workflow.yaml
+++ b/actions/delivery_project_workflow.yaml
@@ -22,4 +22,8 @@ parameters:
     required: true
     type: string
     description: file containing pi emails and projects
-
+  skip_mover:
+    required: false
+    type: boolean
+    default: false
+    description: This can be used to make the delivery service skip running mover - this is only for testing purposes!

--- a/actions/delivery_runfolder_workflow.yaml
+++ b/actions/delivery_runfolder_workflow.yaml
@@ -21,5 +21,9 @@ parameters:
   projects_pi_email_file:
     required: true
     type: string
-    description: file containing pi emails and projects
-
+    description: File containing pi emails and projects
+  skip_mover:
+    required: false
+    type: boolean
+    default: false
+    description: This can be used to make the delivery service skip running mover - this is only for testing purposes!

--- a/actions/delivery_service_delivery_status.yaml
+++ b/actions/delivery_service_delivery_status.yaml
@@ -1,5 +1,5 @@
 ---
-name: delivery_service_deliver
+name: delivery_service_delivery_status
 runner_type: run-python
 description: Delivery a staged folder using the Arteria delivery service
 enabled: true
@@ -10,27 +10,20 @@ parameters:
     action:
         type: string
         required: true
-        default: deliver
+        default: delivery_status
         immutable: true
     ngi_project_name:
         type: string
-        description: NGI project name of the project to deliver
+        description: Name of the ngi project to be delivered
         required: true
-    staging_id:
-        type: integer
-        description: staging id of the folder you want to deliver
-        required: true
-    delivery_project_id:
+    status_link:
         type: string
-        description: delivery project to make the delivery to
+        description: Link to query for status
         required: true
     delivery_base_api_url:
         type: string
         description: url to the delivery service
         required: true
-    md5sum_file:
-      type: string
-      description: (Optional) path to a file with md5sums for Mover to verify
     skip_mover:
       type: boolean
       description: (Optional) skip mover. This should only be used when testing!

--- a/actions/workflows/delivery_project_workflow.yaml
+++ b/actions/workflows/delivery_project_workflow.yaml
@@ -8,6 +8,7 @@ workflows:
         input:
           - project_name
           - projects_pi_email_file
+          - skip_mover
 
         tasks:
             note_workflow_version:
@@ -80,6 +81,23 @@ workflows:
               action: arteria-packs.delivery_service_deliver
               with-items: ngi_project_name in <% $.projects_and_stage_ids.keys() %>
               input:
+                ngi_project_name: <% $.ngi_project_name %>
                 staging_id: <% $.projects_and_stage_ids.get($.ngi_project_name).staging_id %>
                 delivery_base_api_url: <% $.delivery_service_url %>
                 delivery_project_id: <% $.delivery_projects.get($.ngi_project_name).name %>
+                skip_mover: <% $.skip_mover %>
+              publish:
+                delivery_projects_and_links: <% task(deliver_project).result.result %>
+              on-success:
+                - check_delivery_status
+
+            check_delivery_status:
+              action: arteria-packs.delivery_service_delivery_status
+              with-items:
+                - status_link in <% $.delivery_projects_and_links.status_link %>
+                - ngi_project_name in <% $.delivery_projects_and_links.project_name %>
+              input:
+                ngi_project_name: <% $.ngi_project_name %>
+                delivery_base_api_url: <% $.delivery_service_url %>
+                status_link: <% $.status_link %>
+                skip_mover: <% $.skip_mover %>

--- a/actions/workflows/delivery_runfolder_workflow.yaml
+++ b/actions/workflows/delivery_runfolder_workflow.yaml
@@ -8,6 +8,7 @@ workflows:
         input:
           - runfolder_name
           - projects_pi_email_file
+          - skip_mover
           # TODO Later we want to make sure that we can restrict which projects should be delivered...
           #- restrict_to_projects
 
@@ -101,6 +102,23 @@ workflows:
               action: arteria-packs.delivery_service_deliver
               with-items: ngi_project_name in <% $.projects_and_stage_ids.keys() %>
               input:
+                ngi_project_name: <% $.ngi_project_name %>
                 staging_id: <% $.projects_and_stage_ids.get($.ngi_project_name).staging_id %>
                 delivery_base_api_url: <% $.delivery_service_url %>
                 delivery_project_id: <% $.delivery_projects.get($.ngi_project_name).name %>
+                skip_mover: <% $.skip_mover %>
+              publish:
+                delivery_projects_and_links: <% task(deliver_runfolder).result.result %>
+              on-success:
+                - check_delivery_status
+
+            check_delivery_status:
+              action: arteria-packs.delivery_service_delivery_status
+              with-items:
+                - status_link in <% $.delivery_projects_and_links.status_link %>
+                - ngi_project_name in <% $.delivery_projects_and_links.project_name %>
+              input:
+                ngi_project_name: <% $.ngi_project_name %>
+                delivery_base_api_url: <% $.delivery_service_url %>
+                status_link: <% $.status_link %>
+                skip_mover: <% $.skip_mover %>


### PR DESCRIPTION
This introduces a option to the delivery workflows to skip calling mover when running a delivery. This is so that we can do light integration testing without running a real delivery.

It also separates the checking of delivery status from the starting a delivery, so that workflows can be restarted from the status checking stage if we experience intermittent failures.