### PR TITLE
Check ngi ready and configurable polling wait times

### DIFF
--- a/actions/arteria_delivery_service.py
+++ b/actions/arteria_delivery_service.py
@@ -10,8 +10,9 @@ from st2actions.runners.pythonrunner import Action
 
 class ArteriaQuerierBase(object):
 
-    def __init__(self, logger):
+    def __init__(self, logger, sleep_time):
         self.logger = logger
+        self.sleep_time = sleep_time
 
     def valid_status(self):
         raise NotImplementedError("Has to be implemented by inheriting class")
@@ -46,8 +47,7 @@ class ArteriaQuerierBase(object):
         links_results = dict(map(lambda x: (x, None), links))
 
         while not all(map(is_in_end_state, links_results.values())):
-            # TODO Make sleep time configurable
-            time.sleep(5)
+            time.sleep(self.sleep_time)
             update_links(links_results)
             self.logger.info("Updated status, now have: {}".format(links_results))
 
@@ -61,8 +61,8 @@ class ArteriaStagingQuerier(ArteriaQuerierBase):
     staging_pending = 'pending'
     staging_in_progress = 'staging_in_progress'
 
-    def __init__(self, logger):
-        super(ArteriaStagingQuerier, self).__init__(logger)
+    def __init__(self, logger, sleep_time):
+        super(ArteriaStagingQuerier, self).__init__(logger, sleep_time)
 
     def query_for_size(self, link):
         response = requests.get(link)
@@ -79,6 +79,7 @@ class ArteriaStagingQuerier(ArteriaQuerierBase):
         valid_states = [self.staging_successful, self.staging_failed, self.staging_pending, self.staging_in_progress]
         return valid_states
 
+
 class ArteriaDeliveryQuerier(ArteriaQuerierBase):
 
     pending = 'pending'
@@ -94,8 +95,8 @@ class ArteriaDeliveryQuerier(ArteriaQuerierBase):
 
     successful_state = delivery_successful
 
-    def __init__(self, logger):
-        super(ArteriaDeliveryQuerier, self).__init__(logger)
+    def __init__(self, logger, sleep_time):
+        super(ArteriaDeliveryQuerier, self).__init__(logger, sleep_time)
 
     def successful_status(self):
         return self.successful_state
@@ -169,14 +170,14 @@ class ArteriaDeliveryService(Action):
         link = response['delivery_order_link']
         return link
 
-    def stage_and_check_status(self, url, projects):
+    def stage_and_check_status(self, url, sleep_time, projects):
         response = self.stage_delivery(url,
                                        projects)
 
         project_and_links = response['staging_order_links']
         self.logger.info("Projects and links was: {}".format(project_and_links))
         status_links = project_and_links.values()
-        arteria_staging_querier = ArteriaStagingQuerier(self.logger)
+        arteria_staging_querier = ArteriaStagingQuerier(self.logger, sleep_time)
         final_status = arteria_staging_querier.query_for_status(status_links)
         links_to_projects = {v: k for k, v in project_and_links.iteritems()}
 
@@ -197,34 +198,36 @@ class ArteriaDeliveryService(Action):
         self.logger.info("Exit status was: {}, result was: {}".format(exit_status, result))
         return exit_status, result
 
-    def stage_and_check_status_of_runfolder(self, delivery_base_api_url, runfolder_name, projects):
+    def stage_and_check_status_of_runfolder(self, delivery_base_api_url, sleep_time, runfolder_name, projects):
         url = "{}/{}/{}".format(delivery_base_api_url, 'api/1.0/stage/runfolder', runfolder_name)
-        return self.stage_and_check_status(url, projects)
+        return self.stage_and_check_status(url, sleep_time, projects)
 
-    def stage_and_check_status_of_project(self, delivery_base_api_url, project_name):
+    def stage_and_check_status_of_project(self, delivery_base_api_url, sleep_time, project_name):
         url = "{}/{}/{}".format(delivery_base_api_url, 'api/1.0/stage/project', project_name)
-        return self.stage_and_check_status(url, projects=None)
+        return self.stage_and_check_status(url, sleep_time, projects=None)
 
-    def run(self, action, delivery_base_api_url, **kwargs):
+    def run(self, action, delivery_base_api_url, sleep_time, **kwargs):
         if action == "stage_runfolder":
             return self.stage_and_check_status_of_runfolder(delivery_base_api_url,
+                                                            sleep_time,
                                                             kwargs['runfolder_name'],
                                                             kwargs.get('projects'))
 
         elif action == "stage_project":
             return self.stage_and_check_status_of_project(delivery_base_api_url,
+                                                          sleep_time,
                                                           kwargs["project_name"])
 
         elif action == "deliver":
             status_link = self.deliver(delivery_base_api_url,
-                                        kwargs['staging_id'],
-                                        kwargs['delivery_project_id'],
-                                        kwargs.get('md5sum_file'),
-                                        kwargs.get('skip_mover'))
+                                       kwargs['staging_id'],
+                                       kwargs['delivery_project_id'],
+                                       kwargs.get('md5sum_file'),
+                                       kwargs.get('skip_mover'))
             return True, {"project_name": kwargs["ngi_project_name"], "status_link": status_link}
         elif action == "delivery_status":
             status_endpoint = kwargs['status_link']
-            arteria_delivery_querier = ArteriaDeliveryQuerier(self.logger)
+            arteria_delivery_querier = ArteriaDeliveryQuerier(self.logger, sleep_time)
             return arteria_delivery_querier.query_for_status(status_endpoint, kwargs.get('skip_mover'))
         else:
             raise AssertionError("Action: {} was not recognized.".format(action))

--- a/actions/check_ngi_ready_in_supr.yaml
+++ b/actions/check_ngi_ready_in_supr.yaml
@@ -1,0 +1,32 @@
+---
+name: check_ngi_ready_in_supr
+runner_type: run-python
+description: Check if a project has been marked as ngi_ready in supr
+enabled: true
+entry_point: supr.py
+parameters:
+    timeout:
+        default: 10
+    action:
+        type: string
+        required: true
+        default: check_ngi_ready
+        immutable: true
+    project:
+        type: object
+        description: dict with info on the supr project
+        required: true
+    supr_base_api_url:
+        type: string
+        description: Email adress to look for associated PI for.
+        required: false
+        # TODO Change to production instance?
+        default: https://disposer.c3se.chalmers.se/supr-test/api
+    api_user:
+      type: string
+      description: SUPR api user
+      required: true
+    api_key:
+      type: string
+      description: SUPR api key
+      required: true

--- a/actions/delivery_project_workflow.yaml
+++ b/actions/delivery_project_workflow.yaml
@@ -27,3 +27,8 @@ parameters:
     type: boolean
     default: false
     description: This can be used to make the delivery service skip running mover - this is only for testing purposes!
+  sleep_time:
+    required: false
+    type: integer
+    description: Configure the time to sleep in poll steps. Useful to reset when testing to make workflows run faster.
+    default: 300

--- a/actions/delivery_runfolder_workflow.yaml
+++ b/actions/delivery_runfolder_workflow.yaml
@@ -27,3 +27,8 @@ parameters:
     type: boolean
     default: false
     description: This can be used to make the delivery service skip running mover - this is only for testing purposes!
+  sleep_time:
+    required: false
+    type: integer
+    description: Configure the time to sleep in poll steps. Useful to reset when testing to make workflows run faster.
+    default: 300

--- a/actions/delivery_service_deliver.yaml
+++ b/actions/delivery_service_deliver.yaml
@@ -34,4 +34,9 @@ parameters:
     skip_mover:
       type: boolean
       description: (Optional) skip mover. This should only be used when testing!
+    sleep_time:
+        type: integer
+        description: seconds to sleep between polling for status
+        required: true
+        default: 300
 

--- a/actions/delivery_service_delivery_status.yaml
+++ b/actions/delivery_service_delivery_status.yaml
@@ -27,4 +27,9 @@ parameters:
     skip_mover:
       type: boolean
       description: (Optional) skip mover. This should only be used when testing!
+    sleep_time:
+        type: integer
+        description: seconds to sleep between polling for status
+        required: true
+        default: 300
 

--- a/actions/delivery_service_stage_project.yaml
+++ b/actions/delivery_service_stage_project.yaml
@@ -20,3 +20,8 @@ parameters:
         type: string
         description: url to the delivery service
         required: true
+    sleep_time:
+        type: integer
+        description: seconds to sleep between polling for status
+        required: true
+        default: 300

--- a/actions/delivery_service_stage_runfolder.yaml
+++ b/actions/delivery_service_stage_runfolder.yaml
@@ -24,3 +24,8 @@ parameters:
         type: string
         description: url to the delivery service
         required: true
+    sleep_time:
+        type: integer
+        description: seconds to sleep between polling for status
+        required: true
+        default: 300

--- a/actions/supr.py
+++ b/actions/supr.py
@@ -87,6 +87,21 @@ class Supr(Action):
 
         return result
 
+    @staticmethod
+    def check_ngi_ready_status(supr_base_api_url, api_user, api_key, project):
+        project_id = project['id']
+        project_url = '{}/project/{}/'.format(supr_base_api_url, project_id)
+        response = requests.get(project_url, auth=(api_user, api_key))
+        response_as_json = json.loads(response.content)
+        ngi_ready = response_as_json['ngi_ready']
+
+        output_object = {project['ngi_project_name']: response_as_json['ngi_ready']}
+
+        if ngi_ready:
+            return True, output_object
+        else:
+            return False, output_object
+
     def run(self, action, supr_base_api_url, api_user, api_key, **kwargs):
         if action == "get_id_from_email":
             return self.search_for_pis(kwargs['project_to_email_dict'], supr_base_api_url, api_user, api_key)
@@ -95,6 +110,8 @@ class Supr(Action):
                                                 kwargs['project_names_and_ids'],
                                                 kwargs['project_info'],
                                                 api_user, api_key)
+        elif action == 'check_ngi_ready':
+            return self.check_ngi_ready_status(supr_base_api_url, api_user, api_key, kwargs['project'])
         else:
             raise AssertionError("Action: {} was not recognized.".format(action))
 

--- a/actions/workflows/delivery_project_workflow.yaml
+++ b/actions/workflows/delivery_project_workflow.yaml
@@ -9,6 +9,7 @@ workflows:
           - project_name
           - projects_pi_email_file
           - skip_mover
+          - sleep_time
 
         tasks:
             note_workflow_version:
@@ -59,6 +60,7 @@ workflows:
               input:
                  delivery_base_api_url: <% $.delivery_service_url %>
                  project_name: <% $.project_name %>
+                 sleep_time: <% $.sleep_time %>
               publish:
                  projects_and_stage_ids: <% task(stage_project).result.result %>
               on-success:
@@ -69,6 +71,7 @@ workflows:
               input:
                 project_names_and_ids: <% $.pi_supr_ids %>
                 project_info: <% $.projects_and_stage_ids %>
+                supr_base_api_url: <% $.supr_api_url %>
                 api_user: <% $.supr_api_user %>
                 api_key: <% $.supr_api_key %>
               publish:
@@ -101,6 +104,7 @@ workflows:
                 delivery_base_api_url: <% $.delivery_service_url %>
                 status_link: <% $.status_link %>
                 skip_mover: <% $.skip_mover %>
+                sleep_time: <% $.sleep_time %>
               on-success:
                 - check_ngi_ready_status: <% $.skip_mover = false %>
 
@@ -113,3 +117,4 @@ workflows:
                 supr_base_api_url: <% $.supr_api_url %>
                 api_user: <% $.supr_api_user %>
                 api_key: <% $.supr_api_key %>
+

--- a/actions/workflows/delivery_project_workflow.yaml
+++ b/actions/workflows/delivery_project_workflow.yaml
@@ -101,3 +101,15 @@ workflows:
                 delivery_base_api_url: <% $.delivery_service_url %>
                 status_link: <% $.status_link %>
                 skip_mover: <% $.skip_mover %>
+              on-success:
+                - check_ngi_ready_status: <% $.skip_mover = false %>
+
+            check_ngi_ready_status:
+              action: arteria-packs.check_ngi_ready_in_supr
+              with-items:
+                - project in <% $.delivery_projects.keys() %>
+              input:
+                project: <% $.delivery_projects.get($.project) %>
+                supr_base_api_url: <% $.supr_api_url %>
+                api_user: <% $.supr_api_user %>
+                api_key: <% $.supr_api_key %>

--- a/actions/workflows/delivery_runfolder_workflow.yaml
+++ b/actions/workflows/delivery_runfolder_workflow.yaml
@@ -122,3 +122,15 @@ workflows:
                 delivery_base_api_url: <% $.delivery_service_url %>
                 status_link: <% $.status_link %>
                 skip_mover: <% $.skip_mover %>
+              on-success:
+                - check_ngi_ready_status: <% $.skip_mover = false %>
+
+            check_ngi_ready_status:
+              action: arteria-packs.check_ngi_ready_in_supr
+              with-items:
+                - project in <% $.delivery_projects.keys() %>
+              input:
+                project: <% $.delivery_projects.get($.project) %>
+                supr_base_api_url: <% $.supr_api_url %>
+                api_user: <% $.supr_api_user %>
+                api_key: <% $.supr_api_key %>

--- a/actions/workflows/delivery_runfolder_workflow.yaml
+++ b/actions/workflows/delivery_runfolder_workflow.yaml
@@ -9,6 +9,7 @@ workflows:
           - runfolder_name
           - projects_pi_email_file
           - skip_mover
+          - sleep_time
           # TODO Later we want to make sure that we can restrict which projects should be delivered...
           #- restrict_to_projects
 
@@ -80,6 +81,7 @@ workflows:
                  runfolder_name: <% $.runfolder_name %>
                  projects:
                    projects: <% $.projects_on_runfolder %>
+                 sleep_time: <% $.sleep_time %>
               publish:
                  projects_and_stage_ids: <% task(stage_runfolder).result.result %>
               on-success:
@@ -90,6 +92,7 @@ workflows:
               input:
                 project_names_and_ids: <% $.pi_supr_ids %>
                 project_info: <% $.projects_and_stage_ids %>
+                supr_base_api_url: <% $.supr_api_url %>
                 api_user: <% $.supr_api_user %>
                 api_key: <% $.supr_api_key %>
               publish:
@@ -122,6 +125,7 @@ workflows:
                 delivery_base_api_url: <% $.delivery_service_url %>
                 status_link: <% $.status_link %>
                 skip_mover: <% $.skip_mover %>
+                sleep_time: <% $.sleep_time %>
               on-success:
                 - check_ngi_ready_status: <% $.skip_mover = false %>
 


### PR DESCRIPTION
Added a step to the workflow that will check that the `ngi_ready` flag is set in supr. Also made polling wait times configurable, so that we won't spam mover info, etc, every 5 seconds. The default is not 5 minutes, but it is configurable, so that it can be lowered during testing. 