### PR TITLE
Added 5 h timeout for rsync from Irma to Seq-Summaries

### DIFF
--- a/actions/workflows/fill_projman.yaml
+++ b/actions/workflows/fill_projman.yaml
@@ -67,6 +67,7 @@ workflows:
                 hosts: <% $.summary_host %>
                 username: <% $.summary_user %>
                 private_key: <% $.summary_host_key %>
+                timeout: 18000 # 5 h timeout
               concurrency: 5
               on-complete:
                 - check_reports_old_enough


### PR DESCRIPTION
A lot of `rsync_from_irma` tasks in the `fill_projman` workflow fail because they do not finish in 60 s. Since Summary folders be up to ~ 600 Mb, I think the sync should be given more time to complete. 