### PR TITLE
Warn when Irma SSH certs are about to expire

### DIFF
--- a/actions/check_irma_certs.yaml
+++ b/actions/check_irma_certs.yaml
@@ -1,0 +1,20 @@
+---
+name: check_irma_certs
+description: Warn if Irma SSH certs are soon to expire 
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/check_irma_certs.yaml
+pack: arteria-packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: arteria-packs.check_irma_certs
+    immutable: true
+    type: string
+  days:
+    default: 14
+    type: integer
+    description: Warn if cert expires within the specified number of days

--- a/actions/workflows/check_irma_certs.yaml
+++ b/actions/workflows/check_irma_certs.yaml
@@ -1,0 +1,61 @@
+version: "2.0" # mistral version
+name: arteria-packs.check_irma_certs
+description: Logins to all hosts daily and warns if the SSH certs expires within two weeks.
+
+workflows:
+    main:
+        type: direct
+        input:
+          - days
+        task-defaults:
+          on-error:
+            - post_failed_message_to_slack
+
+        tasks:
+            note_workflow_version:
+              action: core.local
+              input:
+                cmd: git rev-parse HEAD
+                cwd: /opt/stackstorm/packs/arteria-packs/
+              on-success:
+                  - get_config
+
+            get_config:
+              action: arteria-packs.get_pack_config
+              publish:
+                biotank_hosts: <% task(get_config).result.result.biotank_hosts %>
+                biotank_user: <% task(get_config).result.result.biotank_user %>
+                biotank_user_key: <% task(get_config).result.result.biotank_user_key %>
+                summary_host: <% task(get_config).result.result.summary_host %>
+                summary_user: <% task(get_config).result.result.summary_user %>
+                summary_host_key: <% task(get_config).result.result.summary_host_key %>
+                slack_channel: <% task(get_config).result.result.check_cert_slack_channel %>
+              on-success:
+                 - get_summary_cert_expiry
+                 - get_biotank_certs_expiries
+
+            get_summary_cert_expiry:
+              action: core.remote
+              input:
+                cmd: EXPIRE=`ssh-keygen -L -f /home/seqsum/.ssh/mm-xlas002-cert.pub | grep Valid | awk '{print $5 }'` && DIFF=$((`date -d "${EXPIRE}" +%s`-`date +%s`)) && if [ ${DIFF} -lt $((60*60*24*<% $.days %>)) ]; then echo "SSH certificate expires within <% $.days %> days!" && false; fi
+                hosts: <% $.summary_host %>
+                username: <% $.summary_user %>
+                private_key: <% $.summary_host_key %>
+
+            get_biotank_certs_expiries: 
+              action: core.remote
+              input: 
+                cmd: EXPIRE=`ssh-keygen -L -f /home/arteria/.ssh/irma_biotank-cert.pub | grep Valid | awk '{print $5 }'` && DIFF=$((`date -d "${EXPIRE}" +%s`-`date +%s`)) && if [ ${DIFF} -lt $((60*60*24*<% $.days %>)) ]; then echo "SSH certificate expires within <% $.days %> days!" && false; fi
+                hosts: <% $.biotank_hosts %>
+                username: <% $.biotank_user %>
+                private_key: <% $.biotank_user_key %>
+
+            post_failed_message_to_slack:
+              action: arteria-packs.post_to_slack
+              input:
+                user: 'Cert Police'
+                emoji_icon: ':robot_face:'
+                channel: <% $.slack_channel %>
+                message: 'SSH certificates for Irma expires within <% $.days %> days! Check details by running: `st2 execution get <% env().st2_execution_id %>`'
+              on-complete:
+                - fail

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,11 @@ summary_host_key: /path/to/ssh/key
 summary_destination: /tmp/summaries/
 summary_ngi_pipeline_reports_destination: /tmp/summaries/ngi_reports
 
+biotank_hosts: mm-xart002,mm-xart003
+biotank_user: arteria
+biotank_user_key: "/path/to/ssh/key"
+check_cert_slack_channel: "#bottest"
+
 remote_host: testuppmax
 remote_user: arteria
 remote_host_key: /path/to/ssh/key

--- a/rules/check_irma_certs.yaml
+++ b/rules/check_irma_certs.yaml
@@ -1,0 +1,17 @@
+---
+name: "arteria-packs.check_irma_certs"
+pack: "arteria-packs"
+description: "Warn if Irma certs expire soon"
+enabled: true
+
+trigger:
+    type: "core.st2.CronTimer"
+    parameters:
+      timezone: "UTC"
+      hour: 07
+      minute: 30
+      second: 0
+
+action:
+    ref: "arteria-packs.check_irma_certs"
+


### PR DESCRIPTION
Simple and dirty check of Irma SSH certs on Arteria associated hosts (compute and seq summary hosts). Will warn if they are about to expire within 14 days by sending a message to a Slack channel each morning. 

"mm-xart003" refers to a manual dummy entry in /etc/hosts so I could test checking vs many hosts in one action. 