### PR TITLE
Rollback ConversionStats workaround

### DIFF
--- a/actions/lib/swap_read_nr_in_conversionstats.sh
+++ b/actions/lib/swap_read_nr_in_conversionstats.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e 
-
-RUNFOLDER=$1
-SWAP_FROM=$2
-SWAP_TO=$3
-
-sed -i -e "s:Read number=\"${SWAP_FROM}\":Read number=\"${SWAP_TO}\":g" ${RUNFOLDER}/Unaligned/Stats/ConversionStats.xml

--- a/actions/ngi_uu_workflow.yaml
+++ b/actions/ngi_uu_workflow.yaml
@@ -47,18 +47,6 @@ parameters:
     default: ""
     type: string
     description: "Any additional arguments to bcl2fastq can be fed here. Note that quoutes (\") are needed around arguments for the to parse properly. E.g. \"--my-first-arg 1 --my-second-arg 2\" "
-  conversionstats_swap_read_nr:
-    default: false
-    type: boolean
-    description: "Set to true to swap read numbers in Unaligned/Stats/ConversionStats.xml due to bug in bcl2fastq"
-  conversionstats_swap_read_from:
-    default: 65
-    type: integer
-    description: "What read number to replace"
-  conversionstats_swap_read_to:
-    default: 1
-    type: integer
-    description: "Value of new read number"
   skip_archiving: 
     default: false
     type: boolean

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -14,9 +14,6 @@ workflows:
             - tiles
             - use_base_mask
             - bcl2fastq_additional_arguments
-            - conversionstats_swap_read_nr
-            - conversionstats_swap_read_from
-            - conversionstats_swap_read_to
             - skip_archiving
             - remove_previous_archive_dir  
         output:
@@ -134,17 +131,6 @@ workflows:
                 action: core.local
                 input:
                     cmd: ssh <% $.host %> "echo <% task(run_bcl2fastq).result.result.response_from_start.response.bcl2fastq_version %> > <% $.runfolder %>/bcl2fastq_version"
-                on-success:
-                    - conversionstats_workaround: <% $.conversionstats_swap_read_nr = true %>
-                    - download_sisyphus_config: <% $.conversionstats_swap_read_nr = false %>
-
-            # Due to a bug in bcl2fastq some read numbers in Unaligned/Stats/ConversionStats.xml will sometimes have the wrong number. 
-            # If the Arteria operator manually sets "conversionstats_swap_read"_nr to "true" then this workaround action will swap 
-            # the incorrect value "conversionstats_swap_read_from" to the requested correct value "conversionstats_swap_read_to". 
-            conversionstats_workaround:
-                action: core.local
-                input:
-                    cmd: ssh <% $.host %> "bash -s" < /opt/stackstorm/packs/arteria-packs/actions/lib/swap_read_nr_in_conversionstats.sh <% $.runfolder %> <% $.conversionstats_swap_read_from %> <% $.conversionstats_swap_read_to %>
                 on-success:
                     - download_sisyphus_config
 


### PR DESCRIPTION
Remove workaround as it is fixed in latest version of bcl2fastq that we are now using. 