### PR TITLE
Update sensitive project info

### DIFF
--- a/actions/create_delivery_project_in_supr.yaml
+++ b/actions/create_delivery_project_in_supr.yaml
@@ -16,10 +16,14 @@ parameters:
         type: object
         required: true
         description: Dictionary of project names to pi ids.
+    staging_info:
+        type: object
+        required: true
+        description: Dictionary with staging information, e.g. the size of the project and its staging id.
     project_info:
         type: object
         required: true
-        description: Dictionary with project information, e.g. the size of the allocation of the project
+        description: Dictionary with information about the project, e.g. if it is sensitive or not.
     supr_base_api_url:
         type: string
         description: Email adress to look for associated PI for.

--- a/actions/get_pi_id_for_email_from_supr.yaml
+++ b/actions/get_pi_id_for_email_from_supr.yaml
@@ -12,7 +12,7 @@ parameters:
         required: true
         default: get_id_from_email
         immutable: true
-    project_to_email_dict:
+    project_to_email_sensitive_dict:
         type: object
         description: dict from project to emails
         required: true

--- a/actions/read_projects_email_file.py
+++ b/actions/read_projects_email_file.py
@@ -19,8 +19,10 @@ class ReadProjectsEmailFile(Action):
             reader = csv.DictReader(csv_file, delimiter=';')
             for row in reader:
                 project = row['project']
+                sensitive = self.str_to_bool(row['sensitive'])
                 if project in projects_list:
-                    result[project] = row['email']
+                    result[project] = {"email": row['email'],"sensitive": sensitive}
+                    
 
         if len(projects_list) == len(result.keys()):
             self.logger.info("Projects given and projects found in file did match...")
@@ -28,3 +30,11 @@ class ReadProjectsEmailFile(Action):
         else:
             self.logger.error("Projects given and projects found in file did not match!")
             return False, {}
+
+    def str_to_bool(self, string):
+        if string == "True":
+            return True
+        elif string == "False":
+            return False
+        else:
+            raise ValueError("{} is not a valid boolean.".format(string))

--- a/actions/workflows/delivery_project_workflow.yaml
+++ b/actions/workflows/delivery_project_workflow.yaml
@@ -53,14 +53,14 @@ workflows:
                   projects:
                    -  <% $.project_name %>
               publish:
-                projects_to_emails: <% task(get_pi_emails).result.result %>
+                projects_to_emails_sensitive: <% task(get_pi_emails).result.result %>
               on-success:
                 - get_pi_ids
 
             get_pi_ids:
               action: arteria-packs.get_pi_id_for_email_from_supr
               input:
-                project_to_email_dict: <% $.projects_to_emails %>
+                project_to_email_sensitive_dict: <% $.projects_to_emails_sensitive %>
                 api_user: <% $.supr_api_user %>
                 api_key: <% $.supr_api_key %>
                 supr_base_api_url: <% $.supr_api_url %>
@@ -85,7 +85,8 @@ workflows:
               action: arteria-packs.create_delivery_project_in_super
               input:
                 project_names_and_ids: <% $.pi_supr_ids %>
-                project_info: <% $.projects_and_stage_ids %>
+                staging_info: <% $.projects_and_stage_ids %>
+                project_info: <% $.projects_to_emails_sensitive %>
                 supr_base_api_url: <% $.supr_api_url %>
                 api_user: <% $.supr_api_user %>
                 api_key: <% $.supr_api_key %>

--- a/actions/workflows/delivery_runfolder_workflow.yaml
+++ b/actions/workflows/delivery_runfolder_workflow.yaml
@@ -66,14 +66,14 @@ workflows:
                 projects:
                   projects: <% $.projects_on_runfolder %>
               publish:
-                projects_to_emails: <% task(get_pi_emails).result.result %>
+                projects_to_emails_sensitive: <% task(get_pi_emails).result.result %>
               on-success:
                 - get_pi_ids
 
             get_pi_ids:
               action: arteria-packs.get_pi_id_for_email_from_supr
               input:
-                project_to_email_dict: <% $.projects_to_emails %>
+                project_to_email_sensitive_dict: <% $.projects_to_emails_sensitive %>
                 api_user: <% $.supr_api_user %>
                 api_key: <% $.supr_api_key %>
                 supr_base_api_url: <% $.supr_api_url %>
@@ -100,7 +100,8 @@ workflows:
               action: arteria-packs.create_delivery_project_in_super
               input:
                 project_names_and_ids: <% $.pi_supr_ids %>
-                project_info: <% $.projects_and_stage_ids %>
+                staging_info: <% $.projects_and_stage_ids %>
+                project_info: <% $.projects_to_emails_sensitive %>
                 supr_base_api_url: <% $.supr_api_url %>
                 api_user: <% $.supr_api_user %>
                 api_key: <% $.supr_api_key %>


### PR DESCRIPTION
Information about sensitive projects will now be sent to SUPR. If a project is sensitive or not is given by the delivery-operator in a text-file used as input in the delivery-workflow.