### PR TITLE
Specify project to be delivered from runfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 arteria-packs
 -------------
 
-NOTE: This is very much a work in progress, mostly containing dummy workflows so far.
-
 StackStorm pack to setup automation workflow taking data from the sequencer to delivery on the remote host...
 
 Development and testing

--- a/actions/arteria_delivery_service.py
+++ b/actions/arteria_delivery_service.py
@@ -130,7 +130,8 @@ class ArteriaDeliveryServiceHandler(object):
             else:
                 payload = {}
         else:
-            payload = {'projects':[restrict_to_projects]}
+            restrict_to_projects_list = restrict_to_projects.split(",")
+            payload = {'projects':restrict_to_projects_list}
 
         response = self._post_to_server(stage_runfolder_endpoint, payload)
         return self.parse_stage_order_ids_from_response(response)

--- a/actions/arteria_delivery_service.py
+++ b/actions/arteria_delivery_service.py
@@ -124,13 +124,13 @@ class ArteriaDeliveryServiceHandler(object):
     def stage_runfolder(self, runfolder_name, projects,restrict_to_projects):
         stage_runfolder_endpoint = '{}/api/1.0/stage/runfolder/{}'.format(self.delivery_service_location, runfolder_name)
 
-        if restrict_to_projects == 'None':
+        if restrict_to_projects == 'keep_all_projects':
             if projects:
                 payload = {'projects': projects['projects']}
             else:
                 payload = {}
         else:
-            restrict_to_projects_list = restrict_to_projects.split(",")
+            restrict_to_projects_list = [proj.strip() for proj in restrict_to_projects.split(",")]
             payload = {'projects':restrict_to_projects_list}
 
         response = self._post_to_server(stage_runfolder_endpoint, payload)

--- a/actions/arteria_delivery_service.py
+++ b/actions/arteria_delivery_service.py
@@ -121,13 +121,16 @@ class ArteriaDeliveryServiceHandler(object):
 
         return result
 
-    def stage_runfolder(self, runfolder_name, projects):
+    def stage_runfolder(self, runfolder_name, projects,restrict_to_projects):
         stage_runfolder_endpoint = '{}/api/1.0/stage/runfolder/{}'.format(self.delivery_service_location, runfolder_name)
 
-        if projects:
-            payload = {'projects': projects['projects']}
+        if restrict_to_projects == 'None':
+            if projects:
+                payload = {'projects': projects['projects']}
+            else:
+                payload = {}
         else:
-            payload = {}
+            payload = {'projects':[restrict_to_projects]}
 
         response = self._post_to_server(stage_runfolder_endpoint, payload)
         return self.parse_stage_order_ids_from_response(response)
@@ -220,7 +223,8 @@ class ArteriaDeliveryService(Action):
 
         if action == "stage_runfolder":
             projects_and_stage_ids = service.stage_runfolder(runfolder_name=kwargs['runfolder_name'],
-                                                             projects=kwargs['projects'])
+                                                             projects=kwargs['projects'],
+                                                             restrict_to_projects=kwargs['restrict_to_projects'])
             return self._await_and_parse_results(projects_and_stage_ids, service, sleep_time)
 
         elif action == "stage_project":

--- a/actions/delivery_runfolder_workflow.yaml
+++ b/actions/delivery_runfolder_workflow.yaml
@@ -36,4 +36,4 @@ parameters:
     required: false
     type: string
     description: Name of specific project/projects to be delivered from runfolder. If several projects are specified separate project names on ,.
-    default: None
+    default: 'keep_all_projects'

--- a/actions/delivery_runfolder_workflow.yaml
+++ b/actions/delivery_runfolder_workflow.yaml
@@ -35,5 +35,5 @@ parameters:
   restrict_to_projects:
     required: false
     type: string
-    description: Name of specific project to be delivered from runfolder.
+    description: Name of specific project/projects to be delivered from runfolder. If several projects are specified separate project names on ,.
     default: None

--- a/actions/delivery_runfolder_workflow.yaml
+++ b/actions/delivery_runfolder_workflow.yaml
@@ -32,3 +32,8 @@ parameters:
     type: integer
     description: Configure the time to sleep in poll steps. Useful to reset when testing to make workflows run faster.
     default: 300
+  restrict_to_projects:
+    required: false
+    type: string
+    description: Name of specific project to be delivered from runfolder.
+    default: None

--- a/actions/delivery_service_stage_runfolder.yaml
+++ b/actions/delivery_service_stage_runfolder.yaml
@@ -33,3 +33,8 @@ parameters:
         required: true
         type: string
         description: A api key for the irma kong api gateway
+    restrict_to_projects:
+        required: false
+        type: string
+        description: Name of specific project to be delivered from runfolder.
+        default: None

--- a/actions/delivery_service_stage_runfolder.yaml
+++ b/actions/delivery_service_stage_runfolder.yaml
@@ -36,5 +36,5 @@ parameters:
     restrict_to_projects:
         required: false
         type: string
-        description: Name of specific project to be delivered from runfolder.
+        description: Name of specific project/projects to be delivered from runfolder. If several projects are specified separate project names on ,.
         default: None

--- a/actions/delivery_service_stage_runfolder.yaml
+++ b/actions/delivery_service_stage_runfolder.yaml
@@ -37,4 +37,4 @@ parameters:
         required: false
         type: string
         description: Name of specific project/projects to be delivered from runfolder. If several projects are specified separate project names on ,.
-        default: None
+        default: 'keep_all_projects'

--- a/actions/supr.py
+++ b/actions/supr.py
@@ -50,7 +50,8 @@ class Supr(Action):
     def create_delivery_project(base_url, project_names_and_ids, staging_info, project_info, user, key):
 
         result = {}
-        for ngi_project_name, pi_id in project_names_and_ids.iteritems():
+        for ngi_project_name in staging_info.keys():
+            pi_id = project_names_and_ids[ngi_project_name]
 
             create_delivery_project_url = '{}/ngi_delivery/project/create/'.format(base_url)
 

--- a/actions/workflows/delivery_runfolder_workflow.yaml
+++ b/actions/workflows/delivery_runfolder_workflow.yaml
@@ -10,6 +10,7 @@ workflows:
           - projects_pi_email_file
           - skip_mover
           - sleep_time
+          - restrict_to_projects
           # TODO Later we want to make sure that we can restrict which projects should be delivered...
           #- restrict_to_projects
         task-defaults:
@@ -91,6 +92,7 @@ workflows:
                    projects: <% $.projects_on_runfolder %>
                  sleep_time: <% $.sleep_time %>
                  irma_api_key: <% $.irma_api_key %>
+                 restrict_to_projects: <% $.restrict_to_projects %>
               publish:
                  projects_and_stage_ids: <% task(stage_runfolder).result.result %>
               on-success:

--- a/utils/prepare_test_env.sh
+++ b/utils/prepare_test_env.sh
@@ -14,7 +14,7 @@ pip install -r requirements-test.txt
 
 # Checkout and install st2 requirements
 git clone https://github.com/StackStorm/st2.git --depth 1 --single-branch --branch v$(cat utils/st2.version.txt) ./st2
-sed -i 's/ipyhton/ipython==5.3.0/' ./st2/test-requirements.txt
+sed -i 's/ipython/ipython==5.3.0/' ./st2/test-requirements.txt
 pip install -r ./st2/requirements.txt
 pip install -r ./st2/test-requirements.txt
 

--- a/utils/prepare_test_env.sh
+++ b/utils/prepare_test_env.sh
@@ -14,6 +14,7 @@ pip install -r requirements-test.txt
 
 # Checkout and install st2 requirements
 git clone https://github.com/StackStorm/st2.git --depth 1 --single-branch --branch v$(cat utils/st2.version.txt) ./st2
+sed -i 's/ipyhton/ipython==5.3.0/' ./st2/test-requirements.txt
 pip install -r ./st2/requirements.txt
 pip install -r ./st2/test-requirements.txt
 


### PR DESCRIPTION
When running the delivery workflow for a runfolder the parameter restrict_to_projects can be used to specify one or several projects to be delivered from the runfolder. Default is to deliver all projects in a runfolder. If the new parameter is used only the specified project/projects will be delivered. If several projects are given as input they should be separated with a comma. Ex, restrict_to_projects=ABC-123,GHI-789