### PR TITLE
Runfolder search and modification to trace_runfolder.py

### DIFF
--- a/scripts/runfolder_search.py
+++ b/scripts/runfolder_search.py
@@ -1,7 +1,8 @@
 import requests
 import json
 import sys
- 
+import yaml
+
 # Usage:
 # python runfolder_search.py <search term>
 
@@ -11,13 +12,18 @@ else:
     print "Missing argument!\nUsage: python search_runfolder.py <search term>"
     sys.exit()
 
-hosts = ["biotank5", "biotank6" ,"biotank7", "biotank8", "biotank9", "biotank10", "biotank11", "biotank12", "biotank13", "biotank14"]
+# Load config
+with open("/opt/stackstorm/packs/arteria-packs/config.yaml", 'r') as ymlfile:
+    cfg = yaml.load(ymlfile)
+
+# Get hosts from config
+hosts = cfg['runfolder_svc_urls']
 
 # Print header
 print "status\trunfolder_link"
 
 for host in hosts:
-    result = requests.get("http://{}:10800/api/1.0/runfolders?state=*".format(host))
+    result = requests.get("{}/api/1.0/runfolders?state=*".format(host))
     result_json = json.loads(result.text)
     all_runfolders = result_json["runfolders"]
     for runfolder in all_runfolders:

--- a/scripts/runfolder_search.py
+++ b/scripts/runfolder_search.py
@@ -1,0 +1,27 @@
+import requests
+import json
+import sys
+ 
+# Usage:
+# python runfolder_search.py <search term>
+
+if len(sys.argv) > 1:
+    search_term = sys.argv[1]
+else:
+    print "Missing argument!\nUsage: python search_runfolder.py <search term>"
+    sys.exit()
+
+hosts = ["biotank5", "biotank6" ,"biotank7", "biotank8", "biotank9", "biotank10", "biotank11", "biotank12", "biotank13", "biotank14"]
+
+# Print header
+print "status\trunfolder_link"
+
+for host in hosts:
+    result = requests.get("http://{}:10800/api/1.0/runfolders?state=*".format(host))
+    result_json = json.loads(result.text)
+    all_runfolders = result_json["runfolders"]
+    for runfolder in all_runfolders:
+        link = runfolder["link"]
+        state = runfolder["state"]
+        if search_term in link:
+            print "{}\t{}".format(state, link)

--- a/scripts/trace_runfolder.py
+++ b/scripts/trace_runfolder.py
@@ -34,7 +34,7 @@ def get_actions_from_executions(executions, headers):
         yield execution_info
 
 def filter_actions_by_name(actions, name):
-    return (action for action in actions if action["action"]["name"] == name)
+    return (action for action in actions if name in action["action"]["name"])
 
 def sort_actions_by_timestamp(actions):
     def get_start_time(action):
@@ -52,7 +52,7 @@ if __name__ == "__main__":
                                              "python scripts/trace_runfolder.py --tag 150605_M00485_0183_000000000-ABGT6_testbio14 | xargs -n1 st2 execution get")
     parser.add_argument('--tag', required=True)
     parser.add_argument('--api_base_url', default="http://localhost:9101/v1")
-    parser.add_argument('--workflow', default="ngi_uu_workflow")
+    parser.add_argument('--workflow', default="workflow")
     args = parser.parse_args()
 
     api_base_url = args.api_base_url


### PR DESCRIPTION
### New script: runfolder_search.py
Enables arteria operators to search for runfolders using e.g. flowcell ID. Output contains runfolder state and biotank information. This script can be improved a lot, but this is a start. Props to @johandahlberg who supplied the backbone of the script. 

### Modified script: trace_runfolder.py
All actions matching "workflow" will now be listed for a certain trace tag. The reason for this is to include delivery workflows as well as archive workflows that have been started manually. The sync_workflow will also be listed, but personally I think that is OK.