### PR TITLE
New delivery workflows

### DIFF
--- a/actions/arteria_delivery_service.py
+++ b/actions/arteria_delivery_service.py
@@ -156,6 +156,12 @@ class ArteriaDeliveryServiceHandler(object):
         response = self._post_to_server(stage_project_endpoint, payload=payload)
         return self.parse_stage_order_ids_from_response(response)
 
+    def stage_runfolders_for_project(self, project_name, mode):
+        stage_project_endpoint = '{}/api/1.0/stage/project/runfolders/{}'.format(self.delivery_service_location, project_name)
+        payload = {'delivery_mode': mode}
+        response = self._post_to_server(stage_project_endpoint, payload=payload)
+        return self.parse_stage_order_ids_from_response(response)
+
     def update_stage_status(self, project_and_stage_id):
         stage_status_endpoint = '{}/api/1.0/stage/{}'.format(self.delivery_service_location,
                                                              project_and_stage_id.stage_id)
@@ -250,6 +256,10 @@ class ArteriaDeliveryService(Action):
                                                            force_delivery=kwargs['force_delivery'])
             return self._await_and_parse_results(projects_and_stage_ids, service, sleep_time)
 
+        elif action == "stage_runfolders_for_project":
+            projects_and_stage_ids = service.stage_runfolders_for_project(project_name=kwargs['project_name'],
+                                                                          mode=kwargs['mode'])
+            return self._await_and_parse_results(projects_and_stage_ids, service, sleep_time)
         elif action == "deliver":
             skip_mover = kwargs.get('skip_mover')
             project_and_delivery_id = service.delivery(ngi_project_name=kwargs['ngi_project_name'],

--- a/actions/delivery_project_workflow.yaml
+++ b/actions/delivery_project_workflow.yaml
@@ -32,3 +32,8 @@ parameters:
     type: integer
     description: Configure the time to sleep in poll steps. Useful to reset when testing to make workflows run faster.
     default: 300
+  force_delivery:
+    required: false
+    type: boolean
+    description: If a project has already been delivered, the delivery service will deny delivering it again. This allows this to be overridden. Use with care!
+    default: false

--- a/actions/delivery_runfolder_workflow.yaml
+++ b/actions/delivery_runfolder_workflow.yaml
@@ -37,3 +37,8 @@ parameters:
     type: string
     description: Name of specific project/projects to be delivered from runfolder. If several projects are specified separate project names on ,.
     default: 'keep_all_projects'
+  force_delivery:
+    required: false
+    type: boolean
+    description: If a runfolder has already been delivered, the delivery service will deny delivering it again. This allows this to be overridden. Use with care!
+    default: false

--- a/actions/delivery_runfolders_for_project_workflow.yaml
+++ b/actions/delivery_runfolders_for_project_workflow.yaml
@@ -1,0 +1,44 @@
+---
+name: delivery_runfolders_for_project_workflow
+description: Deliver a project (i.e. a directory placed in the directory defined by the arteria delivery service `general_project_directory` configuration)
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/delivery_runfolders_for_project_workflow.yaml
+pack: arteria-packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: arteria-packs.delivery_runfolers_for_workflow
+    immutable: true
+    type: string
+  project_name:
+    required: true
+    type: string
+    description: Name of the project (and the directory) to deliver
+  mode:
+    required: true
+    type: string
+    description: The mode of delivery to apply. Can be CLEAN (default), BATCH or FORCE.
+    default: CLEAN
+  projects_pi_email_file:
+    required: true
+    type: string
+    description: file containing pi emails and projects
+  skip_mover:
+    required: false
+    type: boolean
+    default: false
+    description: This can be used to make the delivery service skip running mover - this is only for testing purposes!
+  sleep_time:
+    required: false
+    type: integer
+    description: Configure the time to sleep in poll steps. Useful to reset when testing to make workflows run faster.
+    default: 300
+  force_delivery:
+    required: false
+    type: boolean
+    description: If a project has already been delivered, the delivery service will deny delivering it again. This allows this to be overridden. Use with care!
+    default: false

--- a/actions/delivery_service_stage_project.yaml
+++ b/actions/delivery_service_stage_project.yaml
@@ -30,3 +30,8 @@ parameters:
         secret: true
         type: string
         description: A api key for the irma kong api gateway
+    force_delivery:
+        required: false
+        type: boolean
+        description: If a project has already been delivered, the delivery service will deny delivering it again. This allows this to be overridden. Use with care!
+        default: false

--- a/actions/delivery_service_stage_runfolder.yaml
+++ b/actions/delivery_service_stage_runfolder.yaml
@@ -39,3 +39,8 @@ parameters:
         type: string
         description: Name of specific project/projects to be delivered from runfolder. If several projects are specified separate project names on ,.
         default: 'keep_all_projects'
+    force_delivery:
+        required: false
+        type: boolean
+        description: Force a delivery of this runfolder even if it has been delivered before.
+        default: false

--- a/actions/delivery_service_stage_runfolders_for_project.yaml
+++ b/actions/delivery_service_stage_runfolders_for_project.yaml
@@ -1,0 +1,41 @@
+---
+name: delivery_service_stage_runfolders_for_project
+runner_type: run-python
+description: Stage runfolders for a project through the Arteria delivery service
+enabled: true
+entry_point: arteria_delivery_service.py
+parameters:
+    timeout:
+        default: 86400
+    action:
+        type: string
+        required: true
+        default: stage_runfolders_for_project
+        immutable: true
+    mode:
+        type: string
+        required: true
+        default: CLEAN
+    project_name:
+        type: string
+        description: Name of the project to stage
+        required: true
+    delivery_base_api_url:
+        type: string
+        description: url to the delivery service
+        required: true
+    sleep_time:
+        type: integer
+        description: seconds to sleep between polling for status
+        required: true
+        default: 300
+    irma_api_key:
+        required: true
+        secret: true
+        type: string
+        description: A api key for the irma kong api gateway
+    force_delivery:
+        required: false
+        type: boolean
+        description: If a project has already been delivered, the delivery service will deny delivering it again. This allows this to be overridden. Use with care!
+        default: false

--- a/actions/workflows/delivery_project_workflow.yaml
+++ b/actions/workflows/delivery_project_workflow.yaml
@@ -10,6 +10,7 @@ workflows:
           - projects_pi_email_file
           - skip_mover
           - sleep_time
+          - force_delivery
         task-defaults:
           on-error:
             - post_failed_message_to_slack
@@ -76,6 +77,7 @@ workflows:
                  project_name: <% $.project_name %>
                  sleep_time: <% $.sleep_time %>
                  irma_api_key: <% $.irma_api_key %>
+                 force_delivery: <% $.force_delivery %>
               publish:
                  projects_and_stage_ids: <% task(stage_project).result.result %>
               on-success:

--- a/actions/workflows/delivery_runfolder_workflow.yaml
+++ b/actions/workflows/delivery_runfolder_workflow.yaml
@@ -11,6 +11,7 @@ workflows:
           - skip_mover
           - sleep_time
           - restrict_to_projects
+          - force_delivery
         task-defaults:
           on-error:
             - post_failed_message_to_slack
@@ -92,6 +93,7 @@ workflows:
                  sleep_time: <% $.sleep_time %>
                  irma_api_key: <% $.irma_api_key %>
                  restrict_to_projects: <% $.restrict_to_projects %>
+                 force_delivery: <% $.force_delivery %>
               publish:
                  projects_and_stage_ids: <% task(stage_runfolder).result.result %>
               on-success:

--- a/actions/workflows/delivery_runfolders_for_project_workflow.yaml
+++ b/actions/workflows/delivery_runfolders_for_project_workflow.yaml
@@ -149,7 +149,7 @@ workflows:
                 user: 'Bot D Liver'
                 emoji_icon: ':robot_face:'
                 channel: <% $.delivery_workflow_status_slack_channel %>
-                message: 'I just finished a delivery for `<% $.project_name %>`. You can see the details by running: `st2 execution get <% env().st2_execution_id %>`'
+                message: 'I just finished a runfolder delivery for `<% $.project_name %>`. You can see the details by running: `st2 execution get <% env().st2_execution_id %>`'
 
             post_failed_message_to_slack:
               action: arteria-packs.post_to_slack

--- a/actions/workflows/delivery_runfolders_for_project_workflow.yaml
+++ b/actions/workflows/delivery_runfolders_for_project_workflow.yaml
@@ -1,0 +1,162 @@
+version: "2.0" # mistral version
+name: arteria-packs.delivery_runfolders_for_project_workflow
+description: Deliver runfolders for a specific project to a SNIC delivery project
+
+workflows:
+    main:
+        type: direct
+        input:
+          - project_name
+          - mode
+          - projects_pi_email_file
+          - skip_mover
+          - sleep_time
+          - force_delivery
+        task-defaults:
+          on-error:
+            - post_failed_message_to_slack
+
+        tasks:
+            note_workflow_version:
+              action: core.local
+              input:
+                cmd: git rev-parse HEAD
+                cwd: /opt/stackstorm/packs/arteria-packs/
+              on-success:
+                  - get_config
+
+            get_config:
+              action: arteria-packs.get_pack_config
+              publish:
+                supr_api_user: <% task(get_config).result.result.supr_api_user %>
+                supr_api_key: <% task(get_config).result.result.supr_api_key %>
+                supr_api_url: <% task(get_config).result.result.supr_api_url %>
+                irma_api_key: <% task(get_config).result.result.irma_api_key %>
+                delivery_service_url: <% task(get_config).result.result.delivery_service_url %>
+                delivery_workflow_status_slack_channel: <% task(get_config).result.result.delivery_workflow_status_slack_channel %>
+              on-success:
+                 - post_start_message_to_slack
+
+            post_start_message_to_slack:
+              action: arteria-packs.post_to_slack
+              input:
+                user: 'Bot D Liver'
+                emoji_icon: ':robot_face:'
+                channel: <% $.delivery_workflow_status_slack_channel %>
+                message: 'I just started a delivery of runfolders for `<% $.project_name %>`. You can track my progress by running: `st2 execution get <% env().st2_execution_id %>`'
+              on-success:
+                 - get_pi_emails
+
+            get_pi_emails:
+              action: arteria-packs.read_projects_email_file
+              input:
+                file_path: <% $.projects_pi_email_file %>
+                projects:
+                  projects:
+                   -  <% $.project_name %>
+              publish:
+                projects_to_emails_sensitive: <% task(get_pi_emails).result.result %>
+              on-success:
+                - get_pi_ids
+
+            get_pi_ids:
+              action: arteria-packs.get_pi_id_for_email_from_supr
+              input:
+                project_to_email_sensitive_dict: <% $.projects_to_emails_sensitive %>
+                api_user: <% $.supr_api_user %>
+                api_key: <% $.supr_api_key %>
+                supr_base_api_url: <% $.supr_api_url %>
+              publish:
+                pi_supr_ids: <% task(get_pi_ids).result.result %>
+              on-success:
+                - stage_project
+
+            stage_project:
+              action: arteria-packs.delivery_service_stage_runfolders_for_project
+              input:
+                 mode: <% $.mode %>
+                 delivery_base_api_url: <% $.delivery_service_url %>
+                 project_name: <% $.project_name %>
+                 sleep_time: <% $.sleep_time %>
+                 irma_api_key: <% $.irma_api_key %>
+                 force_delivery: <% $.force_delivery %>
+              publish:
+                 projects_and_stage_ids: <% task(stage_project).result.result %>
+              on-success:
+                - create_delivery_projects
+
+            create_delivery_projects:
+              action: arteria-packs.create_delivery_project_in_super
+              input:
+                project_names_and_ids: <% $.pi_supr_ids %>
+                staging_info: <% $.projects_and_stage_ids %>
+                project_info: <% $.projects_to_emails_sensitive %>
+                supr_base_api_url: <% $.supr_api_url %>
+                api_user: <% $.supr_api_user %>
+                api_key: <% $.supr_api_key %>
+              publish:
+                delivery_projects: <% task(create_delivery_projects).result.result %>
+              on-success:
+                - deliver_project
+
+            # TODO Remember to pass correct md5sum files for the project.
+            deliver_project:
+              action: arteria-packs.delivery_service_deliver
+              with-items: ngi_project_name in <% $.projects_and_stage_ids.keys() %>
+              input:
+                ngi_project_name: <% $.ngi_project_name %>
+                staging_id: <% $.projects_and_stage_ids.get($.ngi_project_name).staging_id %>
+                delivery_base_api_url: <% $.delivery_service_url %>
+                delivery_project_id: <% $.delivery_projects.get($.ngi_project_name).name %>
+                skip_mover: <% $.skip_mover %>
+                irma_api_key: <% $.irma_api_key %>
+              publish:
+                delivery_projects_and_ids: <% task(deliver_project).result.result %>
+              on-success:
+                - check_delivery_status
+
+            check_delivery_status:
+              action: arteria-packs.delivery_service_delivery_status
+              with-items:
+                - id in <% $.delivery_projects_and_ids.delivery_id %>
+                - ngi_project_name in <% $.delivery_projects_and_ids.project_name %>
+              input:
+                ngi_project_name: <% $.ngi_project_name %>
+                delivery_base_api_url: <% $.delivery_service_url %>
+                delivery_id: <% $.id %>
+                skip_mover: <% $.skip_mover %>
+                sleep_time: <% $.sleep_time %>
+                irma_api_key: <% $.irma_api_key %>
+              on-success:
+                - check_ngi_ready_status: <% $.skip_mover = false %>
+                - post_finish_message_to_slack: <% $.skip_mover = true %>
+
+            check_ngi_ready_status:
+              action: arteria-packs.check_ngi_ready_in_supr
+              with-items:
+                - project in <% $.delivery_projects.keys() %>
+              input:
+                project: <% $.delivery_projects.get($.project) %>
+                supr_base_api_url: <% $.supr_api_url %>
+                api_user: <% $.supr_api_user %>
+                api_key: <% $.supr_api_key %>
+              on-success:
+                - post_finish_message_to_slack
+
+            post_finish_message_to_slack:
+              action: arteria-packs.post_to_slack
+              input:
+                user: 'Bot D Liver'
+                emoji_icon: ':robot_face:'
+                channel: <% $.delivery_workflow_status_slack_channel %>
+                message: 'I just finished a delivery for `<% $.project_name %>`. You can see the details by running: `st2 execution get <% env().st2_execution_id %>`'
+
+            post_failed_message_to_slack:
+              action: arteria-packs.post_to_slack
+              input:
+                user: 'Bot D Liver'
+                emoji_icon: ':robot_face:'
+                channel: <% $.delivery_workflow_status_slack_channel %>
+                message: 'Sorry, but I just failed to deliver `<% $.project_name %>`. You can see the details by running: `st2 execution get <% env().st2_execution_id %>`'
+              on-complete:
+                - fail


### PR DESCRIPTION
This brings the delivery workflow up to date with who the `arteria-delivery` service now works, keeping track of previous deliveries. Further more it adds a new workflow to delivery all known runfolders for a project.

This has not yet been fully validated, but informal testing is done, and I think we are ready to merge this.