### PR TITLE
Increased timeout for create delivery project

### DIFF
--- a/actions/create_delivery_project_in_supr.yaml
+++ b/actions/create_delivery_project_in_supr.yaml
@@ -6,7 +6,7 @@ enabled: true
 entry_point: supr.py
 parameters:
     timeout:
-        default: 10
+        default: 600
     action:
         type: string
         required: true


### PR DESCRIPTION
SUPR is sometimes slow to respond, an increase of the timelimit might prevent this action from failing. 