### PR TITLE
incoming folder: make user/key for move command configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,6 +48,9 @@ runfolder_svc_urls:
 incoming_svc_urls:
   - url: http://testarteria1:10850/api/1.0/runfolders/next
     dest_folder: /data/testarteria1/runfolders
+    remote_user: arteria
+    user_key: /home/arteria/.ssh/id_rsa
+
 
 charon_api_token: dummy_token
 charon_base_url: http://charon.url

--- a/rules/mv_runfolders_from_incoming_to_processing.yaml
+++ b/rules/mv_runfolders_from_incoming_to_processing.yaml
@@ -14,4 +14,5 @@ action:
         hosts: "{{ trigger.host }}"
         source: "{{ trigger.runfolder }}"
         destination: "{{ trigger.destination }}"
-
+        username: "{{ trigger.remote_user }}"
+        private_key: "{{ trigger.user_key }}"

--- a/sensors/incoming_sensor.py
+++ b/sensors/incoming_sensor.py
@@ -18,7 +18,12 @@ class IncomingSensor(RunfolderSensor):
         try:
             self._load_config()
             client_urls = [x['url'] for x in self.config["incoming_svc_urls"]]
-            self._destinations = {x['url']: x['dest_folder'] for x in self.config["incoming_svc_urls"]}
+            # copy all further keys of every item over to self._hostconfigs
+            for x in self.config["incoming_svc_urls"]:
+                self._hostconfigs[x['url']] = {}
+                for y in x:
+                    if y != 'url':
+                        self._hostconfigs[x['url']][y] = x[y]
             self._client = RunfolderClient(client_urls, self._logger)
             self._infolog("Created client: {0}".format(self._client))
         except Exception as ex:

--- a/sensors/incoming_sensor.yaml
+++ b/sensors/incoming_sensor.yaml
@@ -20,3 +20,8 @@
             type: "string"
           destination:
             type: "string"
+          remote_user:
+            type: "string"
+          user_key:
+            type: "string"
+

--- a/sensors/runfolder_sensor.py
+++ b/sensors/runfolder_sensor.py
@@ -14,7 +14,7 @@ class RunfolderSensor(PollingSensor):
         self._infolog("__init__")
         self._client = None
         self._trigger = trigger
-        self._destinations = {}
+        self._hostconfigs = {}
 
     def setup(self):
         self._infolog("setup")
@@ -66,8 +66,10 @@ class RunfolderSensor(PollingSensor):
             'timestamp': datetime.utcnow().isoformat(),
             'destination': ""
         }
-        if result['requesturl'] in self._destinations:
-            payload['destination'] = self._destinations[result['requesturl']]
+        if result['requesturl'] in self._hostconfigs:
+            payload['destination'] = self._hostconfigs[result['requesturl']].get('dest_folder', "")
+            payload['remote_user'] = self._hostconfigs[result['requesturl']].get('remote_user', "")
+            payload['user_key'] = self._hostconfigs[result['requesturl']].get('user_key', "")
         self._sensor_service.dispatch(trigger=trigger, payload=payload, trace_tag=runfolder_name)
 
     def _load_config(self):


### PR DESCRIPTION
This patch adds the ability to configure the user and keyfile to use when doing the remote `mv` action for moving runfolders from 'incoming' to 'runfolders'.