### PR TITLE
Adapted script to URLs in config

### DIFF
--- a/scripts/runfolder_search.py
+++ b/scripts/runfolder_search.py
@@ -23,7 +23,8 @@ hosts = cfg['runfolder_svc_urls']
 print "status\trunfolder_link"
 
 for host in hosts:
-    result = requests.get("{}/api/1.0/runfolders?state=*".format(host))
+    url_base = '/'.join(host.split('/')[:-1])
+    result = requests.get("{}?state=*".format(url_base))
     result_json = json.loads(result.text)
     all_runfolders = result_json["runfolders"]
     for runfolder in all_runfolders:


### PR DESCRIPTION
Because of new format of runfolder_svc_urls in config.yaml, runfolder_search.py did not work. This PR adapts the script to the new format. 